### PR TITLE
Reschedule CollectionSource occasionally 

### DIFF
--- a/execution-plane/arcon/experiments/src/bin/perf.rs
+++ b/execution-plane/arcon/experiments/src/bin/perf.rs
@@ -184,7 +184,7 @@ fn exec(
     cfg.threads(kompact_threads);
     if !dedicated {
         cfg.throughput(kompact_throughput as usize);
-        cfg.msg_priority(1.0);
+        cfg.msg_priority(0.5);
     }
 
     let system = cfg.build().expect("KompactSystem");

--- a/execution-plane/arcon/src/stream/source/collection.rs
+++ b/execution-plane/arcon/src/stream/source/collection.rs
@@ -44,19 +44,6 @@ where
             counter: 0,
         }
     }
-    // fn process_collection(&mut self) {
-    //     let mut counter = 0;
-    //     for record in self.collection.drain(..) {
-    //         let elem = self.source_ctx.extract_element(record);
-    //         self.source_ctx.process(elem);
-    //         counter += 1;
-    //         if counter == self.source_ctx.watermark_interval {
-    //             self.source_ctx.generate_watermark();
-    //             counter = 0;
-    //         }
-    //     }
-    //     self.source_ctx.generate_watermark();
-    // }
     fn process_collection(&mut self) {
         let drain_to = RESCHEDULE_EVERY
             .min(self.collection.len());
@@ -113,16 +100,6 @@ where
 }
 
 //ignore_indications!(LoopbackPort, CollectionSource);
-
-// impl<IN, OUT> Actor for CollectionSource<IN, OUT>
-// where
-//     IN: ArconType,
-//     OUT: ArconType,
-// {
-//     type Message = ();
-//     fn receive_local(&mut self, _msg: Self::Message) {}
-//     fn receive_network(&mut self, _msg: NetMessage) {}
-// }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Reschedule CollectionSource occasionally (every 500k elements) so it doesn't execute a single handler forever. 

Kompact doesn't deal well with handlers hanging on to their threads forever. In particular not for the `ControlEvent` handler, since there are internal things that also need to happen in response to these.