### PR TITLE
Use a better shebang in ./run_checks.sh

### DIFF
--- a/execution-plane/run_checks.sh
+++ b/execution-plane/run_checks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cargo test --all --all-features
 cargo check --benches --all --all-features


### PR DESCRIPTION
I, for example, don't have `/bin/bash`.