### PR TITLE
Remove Option from ArconElement

### DIFF
--- a/execution-plane/arcon/src/data/flight_serde.rs
+++ b/execution-plane/arcon/src/data/flight_serde.rs
@@ -192,10 +192,10 @@ mod test {
             let comp_inspect = &comp.definition().lock().unwrap();
             assert_eq!(comp_inspect.data.len() as u64, 4);
             // Verify that the data is correct..
-            assert_eq!(comp_inspect.data[0].data.as_ref().unwrap().items, items);
-            assert_eq!(comp_inspect.data[1].data.as_ref().unwrap().items, items);
-            assert_eq!(comp_inspect.data[2].data.as_ref().unwrap().items, items);
-            assert_eq!(comp_inspect.data[3].data.as_ref().unwrap().items, items);
+            assert_eq!(comp_inspect.data[0].data.items, items);
+            assert_eq!(comp_inspect.data[1].data.items, items);
+            assert_eq!(comp_inspect.data[2].data.items, items);
+            assert_eq!(comp_inspect.data[3].data.items, items);
         }
         let _ = local.shutdown();
         let _ = remote.shutdown();

--- a/execution-plane/arcon/src/data/mod.rs
+++ b/execution-plane/arcon/src/data/mod.rs
@@ -120,8 +120,8 @@ impl<A: ArconType> From<ArconEvent<A>> for ArconEventWrapper<A> {
 #[derive(PMessage, Clone, Abomonation)]
 #[cfg_attr(feature = "arcon_serde", serde(bound = "A: ArconType"))]
 pub struct ArconElement<A: ArconType> {
-    #[prost(message, tag = "1")]
-    pub data: Option<A>,
+    #[prost(message, required, tag = "1")]
+    pub data: A,
     #[prost(message, tag = "2")]
     pub timestamp: Option<u64>,
 }
@@ -130,7 +130,7 @@ impl<A: ArconType> ArconElement<A> {
     /// Creates an ArconElement without a timestamp
     pub fn new(data: A) -> Self {
         ArconElement {
-            data: Some(data),
+            data,
             timestamp: None,
         }
     }
@@ -138,7 +138,7 @@ impl<A: ArconType> ArconElement<A> {
     /// Creates an ArconElement with a timestamp
     pub fn with_timestamp(data: A, ts: u64) -> Self {
         ArconElement {
-            data: Some(data),
+            data,
             timestamp: Some(ts),
         }
     }
@@ -238,12 +238,7 @@ impl<A: ArconType> ArconMessage<A> {
     /// This function should only be used for development and test purposes.
     pub fn element(data: A, timestamp: Option<u64>, sender: NodeID) -> ArconMessage<A> {
         ArconMessage {
-            events: vec![ArconEvent::Element(ArconElement {
-                data: Some(data),
-                timestamp,
-            })
-            .into()]
-            .into(),
+            events: vec![ArconEvent::Element(ArconElement { data, timestamp }).into()].into(),
             sender,
         }
     }

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -18,7 +18,7 @@ extern crate arcon_error as error;
 
 /// Arcon Configuration
 pub mod conf;
-/// Arcon data types, message buffers, serialisers/deserialisers
+/// Arcon data types, serialisers/deserialisers
 pub mod data;
 /// Module containing different runtime managers
 pub mod manager;

--- a/execution-plane/arcon/src/state_backend/faster/mod.rs
+++ b/execution-plane/arcon/src/state_backend/faster/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::{
     prelude::{
         AggregatingStateBuilder, ArconResult, ReducingStateBuilder, ValueStateBuilder,

--- a/execution-plane/arcon/src/state_backend/sled/mod.rs
+++ b/execution-plane/arcon/src/state_backend/sled/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 use crate::{
     prelude::{
         AggregatingStateBuilder, ArconResult, ReducingStateBuilder, ValueStateBuilder,

--- a/execution-plane/arcon/src/stream/node/mod.rs
+++ b/execution-plane/arcon/src/stream/node/mod.rs
@@ -680,8 +680,8 @@ mod tests {
         let data_len = sink_inspect.data.len();
         let epoch_len = sink_inspect.epochs.len();
         assert_eq!(epoch_len, 0);
-        assert_eq!(sink_inspect.data[0].data, Some(1i32));
-        assert_eq!(sink_inspect.data[1].data, Some(3i32));
+        assert_eq!(sink_inspect.data[0].data, 1i32);
+        assert_eq!(sink_inspect.data[1].data, 3i32);
         assert_eq!(data_len, 2);
     }
 
@@ -705,9 +705,9 @@ mod tests {
         let data_len = sink_inspect.data.len();
         let epoch_len = sink_inspect.epochs.len();
         assert_eq!(epoch_len, 0); // no epochs should've completed
-        assert_eq!(sink_inspect.data[0].data, Some(11i32));
-        assert_eq!(sink_inspect.data[1].data, Some(21i32));
-        assert_eq!(sink_inspect.data[2].data, Some(31i32));
+        assert_eq!(sink_inspect.data[0].data, 11i32);
+        assert_eq!(sink_inspect.data[1].data, 21i32);
+        assert_eq!(sink_inspect.data[2].data, 31i32);
         assert_eq!(data_len, 3);
     }
 
@@ -736,12 +736,12 @@ mod tests {
         let data_len = sink_inspect.data.len();
         let epoch_len = sink_inspect.epochs.len();
         assert_eq!(epoch_len, 2); // 3 epochs should've completed
-        assert_eq!(sink_inspect.data[0].data, Some(11i32));
-        assert_eq!(sink_inspect.data[1].data, Some(21i32));
-        assert_eq!(sink_inspect.data[2].data, Some(31i32));
-        assert_eq!(sink_inspect.data[3].data, Some(12i32)); // First message in epoch1
-        assert_eq!(sink_inspect.data[4].data, Some(13i32)); // First message in epoch2
-        assert_eq!(sink_inspect.data[5].data, Some(22i32)); // 2nd message in epoch2
+        assert_eq!(sink_inspect.data[0].data, 11i32);
+        assert_eq!(sink_inspect.data[1].data, 21i32);
+        assert_eq!(sink_inspect.data[2].data, 31i32);
+        assert_eq!(sink_inspect.data[3].data, 12i32); // First message in epoch1
+        assert_eq!(sink_inspect.data[4].data, 13i32); // First message in epoch2
+        assert_eq!(sink_inspect.data[5].data, 22i32); // 2nd message in epoch2
         assert_eq!(data_len, 6);
     }
 }

--- a/execution-plane/arcon/src/stream/operator/function/filter.rs
+++ b/execution-plane/arcon/src/stream/operator/function/filter.rs
@@ -38,10 +38,8 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
-        if let Some(data) = &element.data {
-            if self.run_udf(&data) {
-                ctx.output(ArconEvent::Element(element));
-            }
+        if self.run_udf(&element.data) {
+            ctx.output(ArconEvent::Element(element));
         }
     }
 

--- a/execution-plane/arcon/src/stream/operator/function/filter_map.rs
+++ b/execution-plane/arcon/src/stream/operator/function/filter_map.rs
@@ -44,14 +44,12 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
-        if let Some(data) = element.data {
-            if let Some(result) = self.run_udf(data) {
-                let out_elem = ArconElement {
-                    data: Some(result),
-                    timestamp: element.timestamp,
-                };
-                ctx.output(ArconEvent::Element(out_elem));
-            }
+        if let Some(result) = self.run_udf(element.data) {
+            let out_elem = ArconElement {
+                data: result,
+                timestamp: element.timestamp,
+            };
+            ctx.output(ArconEvent::Element(out_elem));
         }
     }
 
@@ -120,8 +118,8 @@ mod tests {
         {
             let comp_inspect = &comp.definition().lock().unwrap();
             assert_eq!(comp_inspect.data.len(), 2);
-            assert_eq!(comp_inspect.data[0].data, Some(1));
-            assert_eq!(comp_inspect.data[1].data, Some(2));
+            assert_eq!(comp_inspect.data[0].data, 1);
+            assert_eq!(comp_inspect.data[1].data, 2);
         }
 
         pipeline.shutdown();

--- a/execution-plane/arcon/src/stream/operator/function/flatmap.rs
+++ b/execution-plane/arcon/src/stream/operator/function/flatmap.rs
@@ -42,14 +42,12 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
-        if let Some(data) = element.data {
-            let result = self.run_udf(&(data));
-            for item in result {
-                ctx.output(ArconEvent::Element(ArconElement {
-                    data: Some(item),
-                    timestamp: element.timestamp,
-                }));
-            }
+        let result = self.run_udf(&element.data);
+        for item in result {
+            ctx.output(ArconEvent::Element(ArconElement {
+                data: item,
+                timestamp: element.timestamp,
+            }));
         }
     }
 

--- a/execution-plane/arcon/src/stream/operator/function/map.rs
+++ b/execution-plane/arcon/src/stream/operator/function/map.rs
@@ -42,14 +42,12 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
-        if let Some(data) = element.data {
-            let result = self.run_udf(data);
-            let out_elem = ArconElement {
-                data: Some(result),
-                timestamp: element.timestamp,
-            };
-            ctx.output(ArconEvent::Element(out_elem));
-        }
+        let result = self.run_udf(element.data);
+        let out_elem = ArconElement {
+            data: result,
+            timestamp: element.timestamp,
+        };
+        ctx.output(ArconEvent::Element(out_elem));
     }
 
     fn handle_watermark(&mut self, _w: Watermark, _ctx: OperatorContext<Self>) {}
@@ -112,8 +110,8 @@ mod tests {
         {
             let comp_inspect = &comp.definition().lock().unwrap();
             assert_eq!(comp_inspect.data.len(), 2);
-            assert_eq!(comp_inspect.data[0].data, Some(16));
-            assert_eq!(comp_inspect.data[1].data, Some(17));
+            assert_eq!(comp_inspect.data[0].data, 16);
+            assert_eq!(comp_inspect.data[1].data, 17);
         }
         pipeline.shutdown();
     }

--- a/execution-plane/arcon/src/stream/operator/function/map_in_place.rs
+++ b/execution-plane/arcon/src/stream/operator/function/map_in_place.rs
@@ -41,10 +41,8 @@ where
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
         let mut elem = element;
-        if let Some(data) = elem.data.as_mut() {
-            self.run_udf(data);
-            ctx.output(ArconEvent::Element(elem));
-        }
+        self.run_udf(&mut elem.data);
+        ctx.output(ArconEvent::Element(elem));
     }
 
     fn handle_watermark(&mut self, _w: Watermark, _ctx: OperatorContext<Self>) {}

--- a/execution-plane/arcon/src/stream/operator/function/stateful_flat_map.rs
+++ b/execution-plane/arcon/src/stream/operator/function/stateful_flat_map.rs
@@ -41,18 +41,16 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, mut ctx: OperatorContext<Self>) {
-        if let Some(data) = element.data {
-            let result = (self.udf)(
-                // TODO: annoying manual copy required to satisfy borrowchk
-                OperatorContext::new(ctx.channel_strategy, ctx.state_backend, ctx.timer_backend),
-                data,
-            );
-            for item in result {
-                ctx.output(ArconEvent::Element(ArconElement {
-                    data: Some(item),
-                    timestamp: element.timestamp,
-                }));
-            }
+        let result = (self.udf)(
+            // TODO: annoying manual copy required to satisfy borrowchk
+            OperatorContext::new(ctx.channel_strategy, ctx.state_backend, ctx.timer_backend),
+            element.data,
+        );
+        for item in result {
+            ctx.output(ArconEvent::Element(ArconElement {
+                data: item,
+                timestamp: element.timestamp,
+            }));
         }
     }
 
@@ -137,11 +135,7 @@ mod tests {
         {
             let comp_inspect = &comp.definition().lock().unwrap();
             assert_eq!(
-                comp_inspect
-                    .data
-                    .iter()
-                    .map(|x| x.data.unwrap())
-                    .collect::<Vec<_>>(),
+                comp_inspect.data.iter().map(|x| x.data).collect::<Vec<_>>(),
                 vec![3, 5, 7]
             );
         }

--- a/execution-plane/arcon/src/stream/operator/sink/local_file.rs
+++ b/execution-plane/arcon/src/stream/operator/sink/local_file.rs
@@ -45,10 +45,8 @@ where
     type TimerState = ArconNever;
 
     fn handle_element(&mut self, element: ArconElement<IN>, _ctx: OperatorContext<Self>) {
-        if let Some(data) = element.data {
-            if let Err(err) = writeln!(self.file, "{:?}", data) {
-                eprintln!("Error while writing to file sink {}", err.to_string());
-            }
+        if let Err(err) = writeln!(self.file, "{:?}", element.data) {
+            eprintln!("Error while writing to file sink {}", err.to_string());
         }
     }
     fn handle_watermark(&mut self, _w: Watermark, _ctx: OperatorContext<Self>) {}

--- a/execution-plane/arcon/src/stream/operator/window/event_time.rs
+++ b/execution-plane/arcon/src/stream/operator/window/event_time.rs
@@ -191,11 +191,12 @@ where
 
         // Insert the element into all windows and create new where necessary
         for i in floor..=ceil {
-            if let Some(data) = element.data.clone() {
-                self.window
-                    .on_element(data, WindowContext::new(ctx.state_backend, key, i))
-                    .expect("window error");
-            }
+            self.window
+                .on_element(
+                    element.data.clone(),
+                    WindowContext::new(ctx.state_backend, key, i),
+                )
+                .expect("window error");
 
             if !self
                 .active_windows
@@ -363,11 +364,11 @@ mod tests {
         let r1 = &sink_inspect.data.len();
         assert_eq!(r1, &3); // 3 windows received
         let r2 = &sink_inspect.data[0].data;
-        assert_eq!(r2, &Some(2)); // 1st window for key 1 has 2 elements
+        assert_eq!(r2, &2); // 1st window for key 1 has 2 elements
         let r3 = &sink_inspect.data[1].data;
-        assert_eq!(r3, &Some(3)); // 2nd window receieved, key 2, has 3 elements
+        assert_eq!(r3, &3); // 2nd window receieved, key 2, has 3 elements
         let r4 = &sink_inspect.data[2].data;
-        assert_eq!(r4, &Some(1)); // 3rd window receieved, for key 3, has 1 elements
+        assert_eq!(r4, &1); // 3rd window receieved, for key 3, has 1 elements
     }
 
     #[test]
@@ -387,7 +388,7 @@ mod tests {
         // Inspect and assert
         let sink_inspect = sink.definition().lock().unwrap();
         let r1 = &sink_inspect.data[0].data;
-        assert_eq!(r1, &Some(2));
+        assert_eq!(r1, &2);
         let r2 = &sink_inspect.data.len();
         assert_eq!(r2, &1);
     }
@@ -408,7 +409,7 @@ mod tests {
         let sink_inspect = sink.definition().lock().unwrap();
         let r0 = &sink_inspect.data[0].data;
         assert_eq!(&sink_inspect.data.len(), &(1 as usize));
-        assert_eq!(r0, &Some(2));
+        assert_eq!(r0, &2);
     }
     #[test]
     fn window_very_long_windows_1() {
@@ -428,7 +429,7 @@ mod tests {
         wait(1);
         let sink_inspect = sink.definition().lock().unwrap();
         let r0 = &sink_inspect.data[0].data;
-        assert_eq!(r0, &Some(1));
+        assert_eq!(r0, &1);
         assert_eq!(&sink_inspect.data.len(), &(1 as usize));
     }
     #[test]
@@ -449,10 +450,10 @@ mod tests {
         wait(1);
         let sink_inspect = sink.definition().lock().unwrap();
         let r0 = &sink_inspect.data[0].data;
-        assert_eq!(r0, &Some(1));
+        assert_eq!(r0, &1);
         assert_eq!(&sink_inspect.data.len(), &(2 as usize));
         let r1 = &sink_inspect.data[1].data;
-        assert_eq!(r1, &Some(1));
+        assert_eq!(r1, &1);
     }
     #[test]
     fn window_overlapping() {
@@ -472,9 +473,9 @@ mod tests {
         let r2 = &sink_inspect.data.len();
         assert_eq!(r2, &2);
         let r0 = &sink_inspect.data[0].data;
-        assert_eq!(r0, &Some(3));
+        assert_eq!(r0, &3);
         let r1 = &sink_inspect.data[1].data;
-        assert_eq!(r1, &Some(2));
+        assert_eq!(r1, &2);
     }
     #[test]
     fn window_empty() {

--- a/execution-plane/arcon/src/stream/source/local_file.rs
+++ b/execution-plane/arcon/src/stream/source/local_file.rs
@@ -172,7 +172,7 @@ mod tests {
         assert_eq!(&sink_inspect.data.len(), &(50 as usize));
         for item in &sink_inspect.data {
             // all elements should have been mapped + 5
-            assert_eq!(item.data, Some(128));
+            assert_eq!(item.data, 128);
         }
     }
 
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(&sink_inspect.data.len(), &(source_elements as usize));
         for i in 0..source_elements {
             let expected: ArconF64 = ArconF64::new(i as f64 + 0.5);
-            assert_eq!(sink_inspect.data[i].data, Some(expected));
+            assert_eq!(sink_inspect.data[i].data, expected);
         }
     }
 }

--- a/execution-plane/arcon/src/stream/source/socket.rs
+++ b/execution-plane/arcon/src/stream/source/socket.rs
@@ -182,7 +182,7 @@ mod tests {
         let sink_inspect = sink.definition().lock().unwrap();
         assert_eq!(sink_inspect.data.len(), (1 as usize));
         let r0 = &sink_inspect.data[0];
-        assert_eq!(r0.data, Some(77));
+        assert_eq!(r0.data, 77);
     }
 
     #[test]


### PR DESCRIPTION
Removes the unnecessary Rust Option from ``data`` in ArconElement. Closes #98 