### PR TITLE
[WIP] improve flight serde

### DIFF
--- a/execution-plane/arcon/benches/flight_serde.rs
+++ b/execution-plane/arcon/benches/flight_serde.rs
@@ -12,8 +12,7 @@ const NUM_BATCHES: usize = 1000;
 
 fn arcon_flight_serde(c: &mut Criterion) {
     let group = c.benchmark_group("arcon_flight_serde");
-    // Something is broken in the serialisation there,
-    // but if we are anyway changeing it, no point in fixing this now.
+    // NOTE: Leave this commented until issue #103 is fixed.
     //group.bench_function("Arcon Reliable Flight", reliable_serde);
     //group.bench_function("Arcon Unsafe Flight", unsafe_serde);
     group.finish()

--- a/execution-plane/arcon/experiments/src/lib.rs
+++ b/execution-plane/arcon/experiments/src/lib.rs
@@ -10,7 +10,7 @@ pub mod throughput_sink;
 
 use arcon::{macros::*, prelude::*};
 
-#[arcon_keyed(id)]
+#[arcon(unsafe_ser_id = 200, reliable_ser_id = 201, version = 1, keys = id)]
 pub struct Item {
     #[prost(int32, tag = "1")]
     pub id: i32,
@@ -20,7 +20,7 @@ pub struct Item {
     pub scaling_factor: u64,
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 203, reliable_ser_id = 205, version = 1)]
 pub struct EnrichedItem {
     #[prost(int32, tag = "1")]
     pub id: i32,

--- a/execution-plane/arcon/experiments/src/nexmark/mod.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/mod.rs
@@ -10,6 +10,7 @@ pub mod sink;
 pub mod source;
 
 use arcon::macros::*;
+use arcon::prelude::*;
 use config::NEXMarkConfig;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
@@ -29,7 +30,7 @@ impl NEXMarkRNG for SmallRng {
     }
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
 pub struct Person {
     #[prost(uint32, tag = "1")]
     pub id: u32,
@@ -77,7 +78,7 @@ impl Person {
     }
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 106, reliable_ser_id = 107, version = 1)]
 pub struct Auction {
     #[prost(uint32, tag = "1")]
     pub id: u32,
@@ -168,7 +169,7 @@ impl Auction {
     }
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 108, reliable_ser_id = 109, version = 1)]
 pub struct Bid {
     #[prost(uint32, tag = "1")]
     pub auction: u32,
@@ -202,7 +203,7 @@ impl Bid {
     }
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 600, reliable_ser_id = 601, version = 1)]
 pub struct NEXMarkEvent {
     #[prost(oneof = "Event", tags = "1, 2, 3")]
     inner: Option<Event>,

--- a/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
@@ -30,13 +30,13 @@ enum PersonOrAuctionInner {
     Auction(Auction),
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 500, reliable_ser_id = 501, version = 1)]
 pub struct PersonOrAuction {
     #[prost(oneof = "PersonOrAuctionInner", tags = "1, 2")]
     inner: Option<PersonOrAuctionInner>,
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 400, reliable_ser_id = 401, version = 1)]
 pub struct Q3Result {
     #[prost(string, tag = "1")]
     seller_name: String,

--- a/execution-plane/arcon/src/data/flight_serde.rs
+++ b/execution-plane/arcon/src/data/flight_serde.rs
@@ -24,7 +24,7 @@ impl Default for FlightSerde {
 
 /// Module containing the [kompact] serialiser/deserialiser implementation for [FlightSerde::Reliable]
 pub mod reliable_remote {
-    use crate::data::{ArconType, RawArconMessage, VersionId};
+    use crate::data::{ArconType, RawArconMessage};
     use kompact::prelude::*;
     use prost::*;
 
@@ -35,41 +35,24 @@ pub mod reliable_remote {
         const SER_ID: SerId = A::RELIABLE_SER_ID;
 
         fn deserialise(buf: &mut dyn Buf) -> Result<RawArconMessage<A>, SerError> {
-            let version_id = buf.get_u32();
-            if version_id != A::VERSION_ID {
-                let err = format!(
-                    "Mismatch on ArconType version. Got {} while expecting {}",
-                    version_id,
-                    A::VERSION_ID
-                );
-                return Err(SerError::InvalidData(err));
-            }
-
-            let arcon_message = RawArconMessage::decode(buf.bytes()).map_err(|_| {
-                SerError::InvalidData("Failed to decode RawArconMessage".to_string())
-            })?;
-            Ok(arcon_message)
+            RawArconMessage::decode(buf.bytes()).map_err(|e| SerError::InvalidData(e.to_string()))
         }
     }
+
     impl<A: ArconType> Serialisable for ReliableSerde<A> {
         fn ser_id(&self) -> u64 {
             A::RELIABLE_SER_ID
         }
         fn size_hint(&self) -> Option<usize> {
-            let size = std::mem::size_of::<VersionId>() + self.0.encoded_len();
-            Some(size)
+            Some(self.0.encoded_len())
         }
-
         fn serialise(&self, mut buf: &mut dyn BufMut) -> Result<(), SerError> {
-            buf.put_u32(A::VERSION_ID);
-
-            self.0.encode(&mut buf).map_err(|_| {
-                SerError::InvalidData("Failed to encode RawArconMessage".to_string())
-            })?;
+            self.0
+                .encode(&mut buf)
+                .map_err(|e| SerError::InvalidData(e.to_string()))?;
 
             Ok(())
         }
-
         fn local(self: Box<Self>) -> Result<Box<dyn Any + Send>, Box<dyn Serialisable>> {
             Ok(self)
         }
@@ -123,19 +106,17 @@ pub mod unsafe_remote {
             let size = std::mem::size_of::<VersionId>() + abomonation::measure(&self.0);
             Some(size)
         }
-
         fn serialise(&self, buf: &mut dyn BufMut) -> Result<(), SerError> {
             buf.put_u32(A::VERSION_ID);
 
             unsafe {
                 let mut writer = BufMutWriter::new(buf);
                 abomonation::encode(&self.0, &mut writer).map_err(|_| {
-                    SerError::InvalidData("Failed to encode flight data".to_string())
+                    SerError::InvalidData("Failed to encode unsafe flight data".to_string())
                 })?;
             };
             Ok(())
         }
-
         fn local(self: Box<Self>) -> Result<Box<dyn Any + Send>, Box<dyn Serialisable>> {
             Ok(self)
         }
@@ -145,9 +126,80 @@ pub mod unsafe_remote {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{data::test::ArconDataTest, prelude::*};
+    use crate::prelude::*;
     use kompact::prelude::*;
     use std::time::Duration;
+    use once_cell::sync::Lazy;
+
+    static ITEMS: Lazy<Vec<u32>> = Lazy::new(|| vec![1, 2, 3, 4, 5, 6, 7]);
+    const PRICE: u32 = 10;
+    const ID: u32 = 1;
+
+    // The flight_serde pipeline will always send data of ArconDataTest
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
+    pub struct ArconDataTest {
+        #[prost(uint32, tag = "1")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "2")]
+        pub items: Vec<u32>,
+        #[prost(uint32, tag = "3")]
+        pub price: u32,
+    }
+
+    // Down below are different structs the unit tests may attempt to deserialise into
+
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 2)]
+    pub struct UpdatedVer {
+        #[prost(uint32, tag = "1")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "2")]
+        pub items: Vec<u32>,
+        #[prost(uint32, tag = "3")]
+        pub price: u32,
+    }
+
+    #[arcon(unsafe_ser_id = 204, reliable_ser_id = 205, version = 2)]
+    pub struct UpdatedSerId {
+        #[prost(uint32, tag = "1")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "2")]
+        pub items: Vec<u32>,
+        #[prost(uint32, tag = "3")]
+        pub price: u32,
+    }
+
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
+    pub struct RemovedField {
+        #[prost(uint32, tag = "1")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "2")]
+        pub items: Vec<u32>,
+    }
+
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
+    pub struct AddedField {
+        #[prost(uint32, tag = "1")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "2")]
+        pub items: Vec<u32>,
+        #[prost(uint32, tag = "3")]
+        pub price: u32,
+        #[prost(bytes, tag = "4")]
+        pub bytes: Vec<u8>,
+    }
+
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
+    pub struct RearrangedFieldOrder {
+        #[prost(bytes, tag = "1")]
+        pub bytes: Vec<u8>,
+        #[prost(uint32, tag = "2")]
+        pub id: u32,
+        #[prost(uint32, repeated, tag = "3")]
+        pub items: Vec<u32>,
+        #[prost(uint32, tag = "4")]
+        pub price: u32,
+    }
+
     fn get_systems() -> (KompactSystem, KompactSystem) {
         let system = || {
             let mut cfg = KompactConfig::new();
@@ -159,20 +211,79 @@ mod test {
 
     #[test]
     fn reliable_serde_test() {
-        serde_test(FlightSerde::Reliable);
+        let data = flight_test::<ArconDataTest>(FlightSerde::Reliable);
+        for d in data {
+            assert_eq!(d.data.items, *ITEMS);
+            assert_eq!(d.data.price, PRICE);
+            assert_eq!(d.data.id, ID);
+        }
     }
 
     #[test]
     fn unsafe_serde_test() {
-        serde_test(FlightSerde::Unsafe)
+        let data = flight_test::<ArconDataTest>(FlightSerde::Unsafe);
+        for d in data {
+            assert_eq!(d.data.items, *ITEMS);
+            assert_eq!(d.data.price, PRICE);
+            assert_eq!(d.data.id, ID);
+        }
     }
 
-    fn serde_test(serde: FlightSerde) {
+    #[test]
+    #[should_panic]
+    fn unsafe_version_mismatch_test() {
+        // Should panic on ArconType version mismatch
+        // Expected Version 1 but Received Version 2.
+        let _ = flight_test::<UpdatedVer>(FlightSerde::Unsafe);
+    }
+
+    #[test]
+    #[should_panic]
+    fn serde_id_mismatch_test() {
+        // Should panic with Unexpected Deserializer.
+        // reliable/unsafe ser_ids do not match
+        // NOTE: does not matter whether it is Unsafe/Reliable
+        let _ = flight_test::<UpdatedSerId>(FlightSerde::Unsafe);
+    }
+
+    #[test]
+    fn reliable_added_field_test() {
+        let data = flight_test::<AddedField>(FlightSerde::Reliable);
+        for d in data {
+            assert_eq!(d.data.items, *ITEMS);
+            assert_eq!(d.data.price, PRICE);
+            assert_eq!(d.data.id, ID);
+            assert_eq!(d.data.bytes.len(), 0);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn reliable_rearranged_field_test() {
+        // This will fail to deserialize and thus panic
+        let _ = flight_test::<RearrangedFieldOrder>(FlightSerde::Reliable);
+    }
+
+    #[test]
+    fn reliable_removed_field_test() {
+        // Protobuf will still be able to deserialize the data.
+        // Ignoring the sent price field
+        let data = flight_test::<RemovedField>(FlightSerde::Reliable);
+        for d in data {
+            assert_eq!(d.data.id, ID);
+            assert_eq!(d.data.items, *ITEMS);
+        }
+    }
+
+    fn flight_test<ReceivingType>(serde: FlightSerde) -> Vec<ArconElement<ReceivingType>>
+    where
+        ReceivingType: ArconType,
+    {
         let pipeline = ArconPipeline::new();
         let pool_info = pipeline.get_pool_info();
         let (local, remote) = get_systems();
         let timeout = Duration::from_millis(150);
-        let comp = remote.create(move || DebugNode::<ArconDataTest>::new());
+        let comp = remote.create(move || DebugNode::<ReceivingType>::new());
         remote
             .start_notify(&comp)
             .wait_timeout(timeout)
@@ -193,10 +304,10 @@ mod test {
         let mut channel_strategy: ChannelStrategy<ArconDataTest> =
             ChannelStrategy::Forward(Forward::new(channel, 1.into(), pool_info));
 
-        let items = vec![1, 2, 3, 4, 5, 6, 7];
         let data = ArconDataTest {
-            id: 1,
-            items: items.clone(),
+            id: ID,
+            items: ITEMS.clone(),
+            price: PRICE,
         };
         let element = ArconElement::new(data.clone());
         channel_strategy.add(ArconEvent::Element(element.clone()));
@@ -206,16 +317,17 @@ mod test {
         channel_strategy.add(ArconEvent::Element(element));
         channel_strategy.flush();
         std::thread::sleep(timeout);
+
+        let data;
         {
             let comp_inspect = &comp.definition().lock().unwrap();
             assert_eq!(comp_inspect.data.len() as u64, 4);
-            // Verify that the data is correct..
-            assert_eq!(comp_inspect.data[0].data.items, items);
-            assert_eq!(comp_inspect.data[1].data.items, items);
-            assert_eq!(comp_inspect.data[2].data.items, items);
-            assert_eq!(comp_inspect.data[3].data.items, items);
+            data = comp_inspect.data.clone();
         }
+
         let _ = local.shutdown();
         let _ = remote.shutdown();
+
+        return data;
     }
 }

--- a/execution-plane/arcon/src/data/flight_serde.rs
+++ b/execution-plane/arcon/src/data/flight_serde.rs
@@ -24,21 +24,27 @@ impl Default for FlightSerde {
 
 /// Module containing the [kompact] serialiser/deserialiser implementation for [FlightSerde::Reliable]
 pub mod reliable_remote {
-    use crate::data::{ArconType, RawArconMessage};
+    use crate::data::{ArconType, RawArconMessage, VersionId};
     use kompact::prelude::*;
     use prost::*;
 
     #[derive(Clone, Debug)]
     pub struct ReliableSerde<A: ArconType>(pub RawArconMessage<A>);
 
-    impl<A: ArconType> ReliableSerde<A> {
-        const SID: kompact::prelude::SerId = 25;
-    }
-
     impl<A: ArconType> Deserialiser<RawArconMessage<A>> for ReliableSerde<A> {
-        const SER_ID: SerId = Self::SID;
+        const SER_ID: SerId = A::RELIABLE_SER_ID;
 
         fn deserialise(buf: &mut dyn Buf) -> Result<RawArconMessage<A>, SerError> {
+            let version_id = buf.get_u32();
+            if version_id != A::VERSION_ID {
+                let err = format!(
+                    "Mismatch on ArconType version. Got {} while expecting {}",
+                    version_id,
+                    A::VERSION_ID
+                );
+                return Err(SerError::InvalidData(err));
+            }
+
             let arcon_message = RawArconMessage::decode(buf.bytes()).map_err(|_| {
                 SerError::InvalidData("Failed to decode RawArconMessage".to_string())
             })?;
@@ -47,13 +53,16 @@ pub mod reliable_remote {
     }
     impl<A: ArconType> Serialisable for ReliableSerde<A> {
         fn ser_id(&self) -> u64 {
-            Self::SID
+            A::RELIABLE_SER_ID
         }
         fn size_hint(&self) -> Option<usize> {
-            Some(self.0.encoded_len())
+            let size = std::mem::size_of::<VersionId>() + self.0.encoded_len();
+            Some(size)
         }
 
         fn serialise(&self, mut buf: &mut dyn BufMut) -> Result<(), SerError> {
+            buf.put_u32(A::VERSION_ID);
+
             self.0.encode(&mut buf).map_err(|_| {
                 SerError::InvalidData("Failed to encode RawArconMessage".to_string())
             })?;
@@ -69,20 +78,26 @@ pub mod reliable_remote {
 
 /// Module containing the [kompact] serialiser/deserialiser implementation for [FlightSerde::Unsafe]
 pub mod unsafe_remote {
-    use crate::data::{ArconType, BufMutWriter, RawArconMessage};
+    use crate::data::{ArconType, BufMutWriter, RawArconMessage, VersionId};
     use kompact::prelude::*;
 
     #[derive(Clone, Debug)]
     pub struct UnsafeSerde<A: ArconType>(pub RawArconMessage<A>);
 
-    impl<A: ArconType> UnsafeSerde<A> {
-        const SID: kompact::prelude::SerId = 26;
-    }
-
     impl<A: ArconType> Deserialiser<RawArconMessage<A>> for UnsafeSerde<A> {
-        const SER_ID: SerId = Self::SID;
+        const SER_ID: SerId = A::UNSAFE_SER_ID;
 
         fn deserialise(buf: &mut dyn Buf) -> Result<RawArconMessage<A>, SerError> {
+            let version_id = buf.get_u32();
+            if version_id != A::VERSION_ID {
+                let err = format!(
+                    "Mismatch on ArconType version. Got {} while expecting {}",
+                    version_id,
+                    A::VERSION_ID
+                );
+                return Err(SerError::InvalidData(err));
+            }
+
             // TODO: improve
             // But might need a BufMut rather than a Buf...
             let bytes = buf.bytes();
@@ -102,13 +117,16 @@ pub mod unsafe_remote {
 
     impl<A: ArconType> Serialisable for UnsafeSerde<A> {
         fn ser_id(&self) -> u64 {
-            Self::SID
+            A::UNSAFE_SER_ID
         }
         fn size_hint(&self) -> Option<usize> {
-            Some(abomonation::measure(&self.0))
+            let size = std::mem::size_of::<VersionId>() + abomonation::measure(&self.0);
+            Some(size)
         }
 
         fn serialise(&self, buf: &mut dyn BufMut) -> Result<(), SerError> {
+            buf.put_u32(A::VERSION_ID);
+
             unsafe {
                 let mut writer = BufMutWriter::new(buf);
                 abomonation::encode(&self.0, &mut writer).map_err(|_| {

--- a/execution-plane/arcon/src/data/mod.rs
+++ b/execution-plane/arcon/src/data/mod.rs
@@ -488,16 +488,3 @@ impl<'a> std::io::Write for BufMutWriter<'a> {
         Ok(())
     }
 }
-
-#[cfg(test)]
-pub mod test {
-    use super::*;
-
-    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
-    pub struct ArconDataTest {
-        #[prost(uint32, tag = "1")]
-        pub id: u32,
-        #[prost(uint32, repeated, tag = "2")]
-        pub items: Vec<u32>,
-    }
-}

--- a/execution-plane/arcon/src/data/mod.rs
+++ b/execution-plane/arcon/src/data/mod.rs
@@ -3,8 +3,10 @@
 
 /// Serialisers and Deserialiser for in-flight data
 pub mod flight_serde;
+/// Known Serialisation IDs for Arcon Types
+mod ser_id;
 
-use crate::{buffer::event::BufferReader, error::ArconResult, macros::*};
+use crate::{buffer::event::BufferReader, macros::*};
 use abomonation::Abomonation;
 use kompact::prelude::*;
 use prost::{Message as PMessage, Oneof as POneof};
@@ -36,26 +38,20 @@ cfg_if::cfg_if! {
     }
 }
 
+/// A type alias for an ArconType version id
+pub type VersionId = u32;
+
 /// Type that can be passed through the Arcon runtime
 pub trait ArconType: ArconTypeBounds
 where
     Self: std::marker::Sized,
 {
-    /// Encodes `ArconType` into serialised Protobuf data.
-    fn encode_storage(&self) -> ArconResult<Vec<u8>> {
-        let mut buf = Vec::with_capacity(self.encoded_len());
-        self.encode(&mut buf).map_err(|e| {
-            arcon_err_kind!("Failed to encode ArconType with err {}", e.to_string())
-        })?;
-        Ok(buf)
-    }
-    /// Decodes bytes from encoded Protobuf data to `ArconType`
-    fn decode_storage(bytes: &[u8]) -> ArconResult<Self> {
-        let res: Self = Self::decode(bytes).map_err(|e| {
-            arcon_err_kind!("Failed to decode ArconType with err {}", e.to_string())
-        })?;
-        Ok(res)
-    }
+    /// Serialisation ID for Arcon's Unsafe In-flight serde
+    const UNSAFE_SER_ID: SerId;
+    /// Serialisation ID for Arcon's Reliable In-flight serde
+    const RELIABLE_SER_ID: SerId;
+    /// Current version of this ArconType
+    const VERSION_ID: VersionId;
 }
 
 /// An Enum containing all possible stream events that may occur in an execution
@@ -271,14 +267,46 @@ impl Into<u32> for NodeID {
 }
 
 // Implement ArconType for all data types that are supported
-impl ArconType for u32 {}
-impl ArconType for u64 {}
-impl ArconType for i32 {}
-impl ArconType for i64 {}
-impl ArconType for ArconF32 {}
-impl ArconType for ArconF64 {}
-impl ArconType for bool {}
-impl ArconType for String {}
+impl ArconType for u32 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U32_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U32_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for u64 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U64_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U64_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for i32 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I32_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I32_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for i64 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I64_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I64_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for ArconF32 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F32_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F32_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for ArconF64 {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F64_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F64_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for bool {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_BOOLEAN_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_BOOLEAN_ID;
+    const VERSION_ID: VersionId = 1;
+}
+impl ArconType for String {
+    const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_STRING_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_STRING_ID;
+    const VERSION_ID: VersionId = 1;
+}
 
 /// Float wrapper for f32 in order to impl Hash [std::hash::Hash]
 ///
@@ -389,7 +417,11 @@ pub enum ArconNever {}
 impl ArconNever {
     pub const IS_UNREACHABLE: &'static str = "The Never type cannot be instantiated!";
 }
-impl ArconType for ArconNever {}
+impl ArconType for ArconNever {
+    const UNSAFE_SER_ID: SerId = ser_id::NEVER_ID;
+    const RELIABLE_SER_ID: SerId = ser_id::NEVER_ID;
+    const VERSION_ID: VersionId = 1;
+}
 impl fmt::Debug for ArconNever {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unreachable!(ArconNever::IS_UNREACHABLE);
@@ -461,23 +493,11 @@ impl<'a> std::io::Write for BufMutWriter<'a> {
 pub mod test {
     use super::*;
 
-    #[arcon]
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
     pub struct ArconDataTest {
         #[prost(uint32, tag = "1")]
         pub id: u32,
         #[prost(uint32, repeated, tag = "2")]
         pub items: Vec<u32>,
-    }
-
-    #[test]
-    fn arcon_type_serde_test() {
-        let items = vec![1, 2, 3, 4, 5, 6, 7];
-        let data = ArconDataTest {
-            id: 1,
-            items: items.clone(),
-        };
-        let mut bytes = data.encode_storage().unwrap();
-        let decoded = ArconDataTest::decode_storage(&mut bytes).unwrap();
-        assert_eq!(decoded.items, items);
     }
 }

--- a/execution-plane/arcon/src/data/ser_id.rs
+++ b/execution-plane/arcon/src/data/ser_id.rs
@@ -1,0 +1,28 @@
+use kompact::prelude::SerId;
+
+pub const NEVER_ID: SerId = 49;
+
+// Serialisation IDs for Arcon primitives
+pub const UNSAFE_U32_ID: SerId = 50;
+pub const RELIABLE_U32_ID: SerId = 51;
+
+pub const UNSAFE_U64_ID: SerId = 52;
+pub const RELIABLE_U64_ID: SerId = 53;
+
+pub const UNSAFE_I32_ID: SerId = 54;
+pub const RELIABLE_I32_ID: SerId = 55;
+
+pub const UNSAFE_I64_ID: SerId = 56;
+pub const RELIABLE_I64_ID: SerId = 57;
+
+pub const UNSAFE_F32_ID: SerId = 58;
+pub const RELIABLE_F32_ID: SerId = 59;
+
+pub const UNSAFE_F64_ID: SerId = 60;
+pub const RELIABLE_F64_ID: SerId = 61;
+
+pub const UNSAFE_STRING_ID: SerId = 62;
+pub const RELIABLE_STRING_ID: SerId = 63;
+
+pub const UNSAFE_BOOLEAN_ID: SerId = 64;
+pub const RELIABLE_BOOLEAN_ID: SerId = 65;

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -77,6 +77,7 @@ pub mod prelude {
         allocator::{AllocResult, ArconAllocator},
         buffer::event::{BufferPool, BufferReader, BufferWriter},
         conf::ArconConf,
+        data::VersionId,
         pipeline::ArconPipeline,
         stream::{
             channel::{
@@ -97,6 +98,7 @@ pub mod prelude {
         },
         timer,
     };
+    pub use kompact::prelude::SerId;
 
     #[cfg(feature = "kafka")]
     pub use crate::stream::{operator::sink::kafka::KafkaSink, source::kafka::KafkaSource};
@@ -126,10 +128,11 @@ pub mod prelude {
 
 #[cfg(test)]
 mod tests {
-    use crate::macros::*;
+    use crate::{data::VersionId, macros::*};
+    use kompact::prelude::SerId;
     use std::collections::hash_map::DefaultHasher;
 
-    #[arcon_keyed(id)]
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = id)]
     pub struct Item {
         #[prost(uint64, tag = "1")]
         id: u64,

--- a/execution-plane/arcon/src/stream/channel/strategy/mod.rs
+++ b/execution-plane/arcon/src/stream/channel/strategy/mod.rs
@@ -98,8 +98,10 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::data::VersionId;
+    use kompact::prelude::SerId;
 
-    #[arcon_keyed(id)]
+    #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1, keys = id)]
     pub struct Input {
         #[prost(uint32, tag = "1")]
         pub id: u32,

--- a/execution-plane/arcon/src/stream/node/debug.rs
+++ b/execution-plane/arcon/src/stream/node/debug.rs
@@ -101,10 +101,10 @@ where
         let arcon_msg = {
             if ser_id == reliable_id {
                 msg.try_deserialise::<RawArconMessage<IN>, ReliableSerde<IN>>()
-                    .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage"))
+                    .map_err(|e| arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e))
             } else if ser_id == unsafe_id {
                 msg.try_deserialise::<RawArconMessage<IN>, UnsafeSerde<IN>>()
-                    .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage"))
+                    .map_err(|e| arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e))
             } else {
                 panic!("Unexpected deserialiser")
             }

--- a/execution-plane/arcon/src/stream/node/debug.rs
+++ b/execution-plane/arcon/src/stream/node/debug.rs
@@ -94,14 +94,20 @@ where
         self.handle_events(msg.events);
     }
     fn receive_network(&mut self, msg: NetMessage) {
-        let arcon_msg: ArconResult<RawArconMessage<IN>> = match *msg.ser_id() {
-            ReliableSerde::<IN>::SER_ID => msg
-                .try_deserialise::<RawArconMessage<IN>, ReliableSerde<IN>>()
-                .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage")),
-            UnsafeSerde::<IN>::SER_ID => msg
-                .try_deserialise::<RawArconMessage<IN>, UnsafeSerde<IN>>()
-                .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage")),
-            _ => panic!("Unexpected deserialiser"),
+        let unsafe_id = IN::UNSAFE_SER_ID;
+        let reliable_id = IN::RELIABLE_SER_ID;
+        let ser_id = *msg.ser_id();
+
+        let arcon_msg = {
+            if ser_id == reliable_id {
+                msg.try_deserialise::<RawArconMessage<IN>, ReliableSerde<IN>>()
+                    .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage"))
+            } else if ser_id == unsafe_id {
+                msg.try_deserialise::<RawArconMessage<IN>, UnsafeSerde<IN>>()
+                    .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage"))
+            } else {
+                panic!("Unexpected deserialiser")
+            }
         };
 
         match arcon_msg {

--- a/execution-plane/arcon/src/stream/node/mod.rs
+++ b/execution-plane/arcon/src/stream/node/mod.rs
@@ -532,14 +532,20 @@ where
         }
     }
     fn receive_network(&mut self, msg: NetMessage) {
-        let arcon_msg = match *msg.ser_id() {
-            ReliableSerde::<OP::IN>::SER_ID => msg
-                .try_deserialise::<RawArconMessage<OP::IN>, ReliableSerde<OP::IN>>()
-                .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage")),
-            UnsafeSerde::<OP::IN>::SER_ID => msg
-                .try_deserialise::<RawArconMessage<OP::IN>, UnsafeSerde<OP::IN>>()
-                .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage")),
-            _ => panic!("Unexpected deserialiser"),
+        let unsafe_id = OP::IN::UNSAFE_SER_ID;
+        let reliable_id = OP::IN::RELIABLE_SER_ID;
+        let ser_id = *msg.ser_id();
+
+        let arcon_msg = {
+            if ser_id == reliable_id {
+                msg.try_deserialise::<RawArconMessage<OP::IN>, ReliableSerde<OP::IN>>()
+                    .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage"))
+            } else if ser_id == unsafe_id {
+                msg.try_deserialise::<RawArconMessage<OP::IN>, UnsafeSerde<OP::IN>>()
+                    .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage"))
+            } else {
+                panic!("Unexpected deserialiser")
+            }
         };
 
         match arcon_msg {

--- a/execution-plane/arcon/src/stream/node/mod.rs
+++ b/execution-plane/arcon/src/stream/node/mod.rs
@@ -539,10 +539,10 @@ where
         let arcon_msg = {
             if ser_id == reliable_id {
                 msg.try_deserialise::<RawArconMessage<OP::IN>, ReliableSerde<OP::IN>>()
-                    .map_err(|_| arcon_err_kind!("Failed to unpack reliable ArconMessage"))
+                    .map_err(|e| arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e))
             } else if ser_id == unsafe_id {
                 msg.try_deserialise::<RawArconMessage<OP::IN>, UnsafeSerde<OP::IN>>()
-                    .map_err(|_| arcon_err_kind!("Failed to unpack unreliable ArconMessage"))
+                    .map_err(|e| arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e))
             } else {
                 panic!("Unexpected deserialiser")
             }

--- a/execution-plane/arcon/src/stream/operator/window/event_time.rs
+++ b/execution-plane/arcon/src/stream/operator/window/event_time.rs
@@ -253,7 +253,7 @@ mod tests {
     use kompact::prelude::Component;
     use std::{sync::Arc, thread, time, time::UNIX_EPOCH};
 
-    #[arcon_keyed(id)]
+    #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1, keys = id)]
     pub struct Item {
         #[prost(uint64, tag = "1")]
         id: u64,

--- a/execution-plane/arcon/src/stream/source/socket.rs
+++ b/execution-plane/arcon/src/stream/source/socket.rs
@@ -117,7 +117,7 @@ mod tests {
     use crate::{
         data::ArconType,
         pipeline::ArconPipeline,
-        prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map},
+        prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map, SerId, VersionId},
         state_backend::{in_memory::InMemory, StateBackend},
         timer,
     };
@@ -190,7 +190,7 @@ mod tests {
         // Our example data struct for this test case.
         // add arcon_decoder to decode from String
         #[arcon_decoder(,)]
-        #[arcon]
+        #[arcon(unsafe_ser_id = 500, reliable_ser_id = 501, version = 1)]
         pub struct ExtractorStruct {
             #[prost(uint32, tag = "1")]
             data: u32,

--- a/execution-plane/arcon/src/test/recovery_tests.rs
+++ b/execution-plane/arcon/src/test/recovery_tests.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use tempfile::NamedTempFile;
 
-#[arcon]
+#[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
 pub struct NormaliseElements {
     #[prost(int64, repeated, tag = "1")]
     pub data: Vec<i64>,

--- a/execution-plane/arcon/tests/basic_pipeline_tests.rs
+++ b/execution-plane/arcon/tests/basic_pipeline_tests.rs
@@ -14,13 +14,13 @@ use std::{
 };
 use tempfile::NamedTempFile;
 
-#[arcon]
+#[arcon(unsafe_ser_id = 100, reliable_ser_id = 101, version = 1)]
 pub struct NormaliseElements {
     #[prost(int64, repeated, tag = "1")]
     pub data: Vec<i64>,
 }
 
-#[arcon]
+#[arcon(unsafe_ser_id = 98, reliable_ser_id = 99, version = 1)]
 pub struct SourceData {
     #[prost(int64, tag = "1")]
     pub data: i64,


### PR DESCRIPTION
Addresses #94 

ArconType has a new look:

```rust
pub trait ArconType: ArconTypeBounds
where
    Self: std::marker::Sized,
{
    /// Serialisation ID for Arcon's Unsafe In-flight serde
    const UNSAFE_SER_ID: SerId;
    /// Serialisation ID for Arcon's Reliable In-flight serde
    const RELIABLE_SER_ID: SerId;
    /// Current version of this ArconType
    const VERSION_ID: VersionId;
}
```
There is now a single arcon proc macro.

```rust
#[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
pub struct Data {
   #[prost(uint32, tag = "1")]
    pub id: u32,
}
// or
#[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = id)]
pub struct Data {
   #[prost(uint32, tag = "1")]
    pub id: u32,
}
```

Flight Serde now adds the version identifier to the start of the serialised data and checks this at deserialisation:

```rust
impl<A: ArconType> Deserialiser<RawArconMessage<A>> for ReliableSerde<A> {
     const SER_ID: SerId = A::RELIABLE_SER_ID;

     fn deserialise(buf: &mut dyn Buf) -> Result<RawArconMessage<A>, SerError> {
          let version_id = buf.get_u32();
          if version_id != A::VERSION_ID {
              let err = format!(
                  "Mismatch on ArconType version. Got {} while expecting {}",
                  version_id,
                  A::VERSION_ID
              );
              return Err(SerError::InvalidData(err));
          }

          let arcon_message = RawArconMessage::decode(buf.bytes()).map_err(|_| {
              SerError::InvalidData("Failed to decode RawArconMessage".to_string())
          })?;
          Ok(arcon_message)
     }
}
```
Thoughts?

Added a WIP tag to the PR as I want to still fix the flight serde benches. 