### PR TITLE
Arcon derive + Proto Gen

### DIFF
--- a/execution-plane/Cargo.lock
+++ b/execution-plane/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50e2a046af56a864c62d97b7153fda72c596e646be1b0c7963736821f6e1efa"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "synstructure",
 ]
 
@@ -76,7 +76,7 @@ dependencies = [
  "fxhash",
  "hierarchical_hash_wheel_timer",
  "hocon",
- "itertools",
+ "itertools 0.8.2",
  "kompact",
  "lz4-compression",
  "num-rational",
@@ -117,7 +117,7 @@ name = "arcon_macros"
 version = "0.1.3"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -138,7 +138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609c78bd572f4edc74310dfb63a01f5609d53fa8b4dd7c4d98aef3b3e8d72d1"
 dependencies = [
  "proc-macro-hack",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
  "libc",
@@ -251,7 +251,7 @@ dependencies = [
  "quote 0.6.13",
  "regex",
  "shlex",
- "which",
+ "which 2.0.1",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ dependencies = [
  "quote 0.6.13",
  "regex",
  "shlex",
- "which",
+ "which 2.0.1",
 ]
 
 [[package]]
@@ -489,16 +489,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
+checksum = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -514,12 +514,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
+checksum = "ddeaf7989f00f2e1d871a26a110f3ed713632feac17f65f03ca938c542618b60"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.9.0",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -698,7 +698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -885,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
  "synstructure",
 ]
@@ -902,6 +902,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fnv"
@@ -1003,7 +1009,7 @@ checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -1065,6 +1071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1146,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1153,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1173,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "kompact"
 version = "0.9.0"
-source = "git+https://github.com/kompics/kompact.git#dccaa258f2e4e168a11ceb95f711a8b1622bf6f4"
+source = "git+https://github.com/kompics/kompact.git#a0322a4e8660dbd95bc632389f4ab28673b7dd1a"
 dependencies = [
  "arc-swap 0.3.11",
  "as_num",
@@ -1209,20 +1242,20 @@ dependencies = [
 [[package]]
 name = "kompact-actor-derive"
 version = "0.9.0"
-source = "git+https://github.com/kompics/kompact.git#dccaa258f2e4e168a11ceb95f711a8b1622bf6f4"
+source = "git+https://github.com/kompics/kompact.git#a0322a4e8660dbd95bc632389f4ab28673b7dd1a"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
 [[package]]
 name = "kompact-component-derive"
 version = "0.9.0"
-source = "git+https://github.com/kompics/kompact.git#dccaa258f2e4e168a11ceb95f711a8b1622bf6f4"
+source = "git+https://github.com/kompics/kompact.git#a0322a4e8660dbd95bc632389f4ab28673b7dd1a"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -1418,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+
+[[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1569,7 @@ checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -1548,9 +1587,9 @@ checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
 name = "oorandom"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+checksum = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
 
 [[package]]
 name = "parking_lot"
@@ -1581,6 +1620,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "petgraph"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1702,14 +1751,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.8.2",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types",
+ "tempfile",
+ "which 3.1.1",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.6.1"
 source = "git+https://github.com/Max-Meldrum/prost.git?branch=derive_generics#fcdefe99a14c7a549069fff9b5c12983e0799ccf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -1720,9 +1787,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -1734,6 +1801,19 @@ checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proto_tests"
+version = "0.1.0"
+dependencies = [
+ "abomonation",
+ "abomonation_derive",
+ "arcon",
+ "cfg-if",
+ "prost 0.6.1 (git+https://github.com/Max-Meldrum/prost.git?branch=derive_generics)",
+ "prost-build",
+ "serde",
 ]
 
 [[package]]
@@ -1768,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2 1.0.10",
 ]
@@ -2146,15 +2226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2168,7 +2248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -2180,9 +2260,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
+checksum = "7c0893246f276ba1aac4983fb8711dad108e2886fd76bf618a382ab4e30e5bec"
 dependencies = [
  "libc",
  "mio 0.6.21",
@@ -2289,7 +2369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec32ba84a7a86aeb0bc32fd0c46d31b0285599f68ea72e87eff6127889d99e1"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -2324,7 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "unicode-xid 0.2.0",
 ]
 
@@ -2344,7 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
  "unicode-xid 0.2.0",
 ]
@@ -2457,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2486,7 +2566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
 ]
 
@@ -2522,7 +2602,7 @@ dependencies = [
  "cassowary",
  "crossterm 0.14.2",
  "either",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "unicode-segmentation",
  "unicode-width",
@@ -2605,9 +2685,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2615,37 +2695,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.4",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.3",
+ "quote 1.0.4",
  "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -2653,15 +2733,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2674,6 +2754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 dependencies = [
  "failure",
+ "libc",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
  "libc",
 ]
 

--- a/execution-plane/Cargo.toml
+++ b/execution-plane/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
   "arcon",
-  "arcon/experiments"
+  "arcon/experiments",
+  "arcon/proto_tests"
 ]
 
 # TODO fix these later again

--- a/execution-plane/arcon/benches/serde.rs
+++ b/execution-plane/arcon/benches/serde.rs
@@ -3,7 +3,7 @@
 
 // Benchmarks for serialisation/deserialisation
 
-use arcon::macros::*;
+use abomonation_derive::*;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Bencher, Criterion};
 use lz4_compression::prelude::{compress, decompress};
 use prost::Message;

--- a/execution-plane/arcon/experiments/src/lib.rs
+++ b/execution-plane/arcon/experiments/src/lib.rs
@@ -8,7 +8,7 @@ extern crate anyhow;
 pub mod nexmark;
 pub mod throughput_sink;
 
-use arcon::{macros::*, prelude::*};
+use arcon::prelude::*;
 
 #[derive(
     arcon::Arcon,

--- a/execution-plane/arcon/experiments/src/lib.rs
+++ b/execution-plane/arcon/experiments/src/lib.rs
@@ -10,7 +10,15 @@ pub mod throughput_sink;
 
 use arcon::{macros::*, prelude::*};
 
-#[arcon(unsafe_ser_id = 200, reliable_ser_id = 201, version = 1, keys = id)]
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
+#[arcon(unsafe_ser_id = 200, reliable_ser_id = 201, version = 1, keys = "id")]
 pub struct Item {
     #[prost(int32, tag = "1")]
     pub id: i32,
@@ -20,6 +28,14 @@ pub struct Item {
     pub scaling_factor: u64,
 }
 
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 203, reliable_ser_id = 205, version = 1)]
 pub struct EnrichedItem {
     #[prost(int32, tag = "1")]

--- a/execution-plane/arcon/experiments/src/nexmark/mod.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/mod.rs
@@ -9,8 +9,7 @@ pub mod queries;
 pub mod sink;
 pub mod source;
 
-use arcon::macros::*;
-use arcon::prelude::*;
+use arcon::{macros::*, prelude::*};
 use config::NEXMarkConfig;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
@@ -30,6 +29,14 @@ impl NEXMarkRNG for SmallRng {
     }
 }
 
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
 pub struct Person {
     #[prost(uint32, tag = "1")]
@@ -78,6 +85,14 @@ impl Person {
     }
 }
 
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 106, reliable_ser_id = 107, version = 1)]
 pub struct Auction {
     #[prost(uint32, tag = "1")]
@@ -169,6 +184,14 @@ impl Auction {
     }
 }
 
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 108, reliable_ser_id = 109, version = 1)]
 pub struct Bid {
     #[prost(uint32, tag = "1")]
@@ -203,6 +226,14 @@ impl Bid {
     }
 }
 
+#[derive(
+    arcon::Arcon,
+    serde::Serialize,
+    serde::Deserialize,
+    prost::Message,
+    Clone,
+    abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 600, reliable_ser_id = 601, version = 1)]
 pub struct NEXMarkEvent {
     #[prost(oneof = "Event", tags = "1, 2, 3")]

--- a/execution-plane/arcon/experiments/src/nexmark/mod.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/mod.rs
@@ -9,7 +9,7 @@ pub mod queries;
 pub mod sink;
 pub mod source;
 
-use arcon::{macros::*, prelude::*};
+use arcon::prelude::*;
 use config::NEXMarkConfig;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
@@ -291,7 +291,7 @@ impl NEXMarkEvent {
     }
 }
 
-#[derive(prost::Oneof, Serialize, Deserialize, Clone, Abomonation, Hash)]
+#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation, Hash)]
 pub enum Event {
     #[prost(message, tag = "1")]
     Person(Person),

--- a/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
@@ -30,12 +30,18 @@ enum PersonOrAuctionInner {
     Auction(Auction),
 }
 
+#[derive(
+    arcon::Arcon, Serialize, Deserialize, prost::Message, Clone, abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 500, reliable_ser_id = 501, version = 1)]
 pub struct PersonOrAuction {
     #[prost(oneof = "PersonOrAuctionInner", tags = "1, 2")]
     inner: Option<PersonOrAuctionInner>,
 }
 
+#[derive(
+    arcon::Arcon, Serialize, Deserialize, prost::Message, Clone, abomonation_derive::Abomonation,
+)]
 #[arcon(unsafe_ser_id = 400, reliable_ser_id = 401, version = 1)]
 pub struct Q3Result {
     #[prost(string, tag = "1")]

--- a/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
@@ -7,7 +7,6 @@ use crate::nexmark::{
     Auction, Event, NEXMarkEvent, Person,
 };
 use arcon::{
-    macros::*,
     prelude::*,
     stream::operator::{function::StatefulFlatMap, OperatorContext},
     timer,
@@ -22,7 +21,7 @@ use serde::{Deserialize, Serialize};
 //      AND open_auction.itemid = item.id
 //      AND item.categoryId = 10;
 
-#[derive(prost::Oneof, Serialize, Deserialize, Clone, Abomonation, Hash)]
+#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation, Hash)]
 enum PersonOrAuctionInner {
     #[prost(message, tag = "1")]
     Person(Person),

--- a/execution-plane/arcon/proto_tests/Cargo.toml
+++ b/execution-plane/arcon/proto_tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "proto_tests"
+version = "0.1.0"
+authors = ["Max Meldrum <mmeldrum@kth.se>"]
+edition = "2018"
+publish = false
+
+[features]
+arcon_serde = ["arcon/arcon_serde"]
+
+[dependencies]
+arcon = { path = "../" }
+serde = { version = "1.0.104", features = ["derive"] }
+abomonation = "0.7.3"
+abomonation_derive = "0.5.0"
+prost = { git = "https://github.com/Max-Meldrum/prost.git", branch = "derive_generics" }
+
+[build-dependencies]
+prost-build = "0.6"
+cfg-if = "0.1.10"

--- a/execution-plane/arcon/proto_tests/build.rs
+++ b/execution-plane/arcon/proto_tests/build.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+extern crate cfg_if;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut basic_v3_cfg = prost_cfg();
+    basic_v3_cfg.type_attribute(".", &arcon_attr(104, 105, 1));
+
+    basic_v3_cfg
+        .compile_protos(&["src/basic_v3.proto"], &["src/"])
+        .unwrap();
+
+    Ok(())
+}
+
+fn prost_cfg() -> prost_build::Config {
+    let mut config = prost_build::Config::new();
+    config.type_attribute(
+        ".",
+        "#[cfg_attr(feature = \"arcon_serde\", derive(serde::Serialize, serde::Deserialize))]",
+    );
+
+    config.type_attribute(
+        ".",
+        "#[derive(arcon::Arcon, abomonation_derive::Abomonation)]",
+    );
+
+    config
+}
+
+fn arcon_attr(unsafe_ser_id: usize, reliable_ser_id: usize, version: usize) -> String {
+    format!(
+        "#[arcon(unsafe_ser_id = {}, reliable_ser_id = {}, version = {})]",
+        unsafe_ser_id, reliable_ser_id, version
+    )
+}

--- a/execution-plane/arcon/proto_tests/src/basic_v3.proto
+++ b/execution-plane/arcon/proto_tests/src/basic_v3.proto
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+syntax = "proto3";
+
+package arcon_basic_v3;
+
+message SearchRequest {
+  string query = 1;
+  int32 page_number = 2;
+  int32 result_per_page = 3;
+}
+
+message SearchBatch {
+  repeated SearchRequest requests = 1;
+  string id = 2;
+}
+
+message NestedMessage {
+  repeated SearchBatch batches = 1;
+  bytes raw_bytes = 2;
+}
+
+// TODO: add more with oneof etc..

--- a/execution-plane/arcon/proto_tests/src/lib.rs
+++ b/execution-plane/arcon/proto_tests/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! This crate verifies that Protobuf files can be converted into an Arcon supported format.
+//!
+//! NOTE: Only Protobuf version 3 is being tested at the moment.
+
+pub mod basic_v3 {
+    use arcon::*;
+    include!(concat!(env!("OUT_DIR"), "/arcon_basic_v3.rs"));
+}

--- a/execution-plane/arcon/src/data/flight_serde.rs
+++ b/execution-plane/arcon/src/data/flight_serde.rs
@@ -128,14 +128,16 @@ mod test {
     use super::*;
     use crate::prelude::*;
     use kompact::prelude::*;
-    use std::time::Duration;
     use once_cell::sync::Lazy;
+    use std::time::Duration;
 
     static ITEMS: Lazy<Vec<u32>> = Lazy::new(|| vec![1, 2, 3, 4, 5, 6, 7]);
     const PRICE: u32 = 10;
     const ID: u32 = 1;
 
     // The flight_serde pipeline will always send data of ArconDataTest
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
     pub struct ArconDataTest {
         #[prost(uint32, tag = "1")]
@@ -148,6 +150,8 @@ mod test {
 
     // Down below are different structs the unit tests may attempt to deserialise into
 
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 2)]
     pub struct UpdatedVer {
         #[prost(uint32, tag = "1")]
@@ -158,6 +162,8 @@ mod test {
         pub price: u32,
     }
 
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 204, reliable_ser_id = 205, version = 2)]
     pub struct UpdatedSerId {
         #[prost(uint32, tag = "1")]
@@ -168,6 +174,8 @@ mod test {
         pub price: u32,
     }
 
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
     pub struct RemovedField {
         #[prost(uint32, tag = "1")]
@@ -176,6 +184,8 @@ mod test {
         pub items: Vec<u32>,
     }
 
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
     pub struct AddedField {
         #[prost(uint32, tag = "1")]
@@ -188,6 +198,8 @@ mod test {
         pub bytes: Vec<u8>,
     }
 
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1)]
     pub struct RearrangedFieldOrder {
         #[prost(bytes, tag = "1")]

--- a/execution-plane/arcon/src/data/mod.rs
+++ b/execution-plane/arcon/src/data/mod.rs
@@ -6,8 +6,9 @@ pub mod flight_serde;
 /// Known Serialisation IDs for Arcon Types
 mod ser_id;
 
-use crate::{buffer::event::BufferReader, macros::*};
+use crate::buffer::event::BufferReader;
 use abomonation::Abomonation;
+use abomonation_derive::*;
 use kompact::prelude::*;
 use prost::{Message as PMessage, Oneof as POneof};
 #[cfg(feature = "arcon_serde")]

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -9,17 +9,14 @@
 
 #![feature(unboxed_closures)]
 
-#[allow(unused_imports)]
 #[cfg_attr(test, macro_use)]
 extern crate arcon_macros;
 #[doc(hidden)]
-pub use abomonation;
-#[doc(hidden)]
-pub use abomonation_derive::*;
-#[doc(hidden)]
 pub use arcon_macros::*;
-#[doc(hidden)]
-pub use prost;
+
+// Imports below are exposed for #[derive(Arcon)]
+pub use crate::data::{ArconType, VersionId};
+pub use kompact::prelude::SerId;
 
 #[macro_use]
 extern crate arcon_error as error;
@@ -67,13 +64,6 @@ pub mod test_utils {
 
     pub static ALLOCATOR: Lazy<Arc<Mutex<ArconAllocator>>> =
         Lazy::new(|| Arc::new(Mutex::new(ArconAllocator::new(1073741824))));
-}
-
-/// Helper module to fetch all macros related to arcon
-pub mod macros {
-    pub use crate::data::ArconType;
-    pub use abomonation_derive::*;
-    //pub use arcon_macros::*;
 }
 
 /// Helper module that imports everything related to arcon into scope
@@ -138,8 +128,7 @@ pub mod prelude {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::{data::VersionId, macros::*};
-    use kompact::prelude::SerId;
+    use super::*;
     use std::collections::hash_map::DefaultHasher;
 
     #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -9,8 +9,18 @@
 
 #![feature(unboxed_closures)]
 
+#[allow(unused_imports)]
 #[cfg_attr(test, macro_use)]
 extern crate arcon_macros;
+#[doc(hidden)]
+pub use abomonation;
+#[doc(hidden)]
+pub use abomonation_derive::*;
+#[doc(hidden)]
+pub use arcon_macros::*;
+#[doc(hidden)]
+pub use prost;
+
 #[macro_use]
 extern crate arcon_error as error;
 
@@ -63,7 +73,7 @@ pub mod test_utils {
 pub mod macros {
     pub use crate::data::ArconType;
     pub use abomonation_derive::*;
-    pub use arcon_macros::*;
+    //pub use arcon_macros::*;
 }
 
 /// Helper module that imports everything related to arcon into scope
@@ -127,21 +137,23 @@ pub mod prelude {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::{data::VersionId, macros::*};
     use kompact::prelude::SerId;
     use std::collections::hash_map::DefaultHasher;
 
-    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = id)]
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
+    #[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = "id")]
     pub struct Item {
         #[prost(uint64, tag = "1")]
-        id: u64,
+        pub id: u64,
         #[prost(uint32, tag = "2")]
-        price: u32,
+        pub price: u32,
     }
 
     #[test]
-    fn key_by_macro_test() {
+    fn arcon_key_test() {
         let i1 = Item { id: 1, price: 20 };
         let i2 = Item { id: 2, price: 150 };
         let i3 = Item { id: 1, price: 50 };

--- a/execution-plane/arcon/src/stream/channel/strategy/mod.rs
+++ b/execution-plane/arcon/src/stream/channel/strategy/mod.rs
@@ -101,7 +101,9 @@ pub mod tests {
     use crate::data::VersionId;
     use kompact::prelude::SerId;
 
-    #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1, keys = id)]
+    #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
+    #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
     pub struct Input {
         #[prost(uint32, tag = "1")]
         pub id: u32,

--- a/execution-plane/arcon/src/stream/node/debug.rs
+++ b/execution-plane/arcon/src/stream/node/debug.rs
@@ -101,10 +101,14 @@ where
         let arcon_msg = {
             if ser_id == reliable_id {
                 msg.try_deserialise::<RawArconMessage<IN>, ReliableSerde<IN>>()
-                    .map_err(|e| arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e))
+                    .map_err(|e| {
+                        arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e)
+                    })
             } else if ser_id == unsafe_id {
                 msg.try_deserialise::<RawArconMessage<IN>, UnsafeSerde<IN>>()
-                    .map_err(|e| arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e))
+                    .map_err(|e| {
+                        arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e)
+                    })
             } else {
                 panic!("Unexpected deserialiser")
             }

--- a/execution-plane/arcon/src/stream/node/mod.rs
+++ b/execution-plane/arcon/src/stream/node/mod.rs
@@ -539,10 +539,14 @@ where
         let arcon_msg = {
             if ser_id == reliable_id {
                 msg.try_deserialise::<RawArconMessage<OP::IN>, ReliableSerde<OP::IN>>()
-                    .map_err(|e| arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e))
+                    .map_err(|e| {
+                        arcon_err_kind!("Failed to unpack reliable ArconMessage with err {:?}", e)
+                    })
             } else if ser_id == unsafe_id {
                 msg.try_deserialise::<RawArconMessage<OP::IN>, UnsafeSerde<OP::IN>>()
-                    .map_err(|e| arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e))
+                    .map_err(|e| {
+                        arcon_err_kind!("Failed to unpack unreliable ArconMessage with err {:?}", e)
+                    })
             } else {
                 panic!("Unexpected deserialiser")
             }

--- a/execution-plane/arcon/src/stream/operator/window/event_time.rs
+++ b/execution-plane/arcon/src/stream/operator/window/event_time.rs
@@ -248,18 +248,11 @@ mod tests {
     use super::*;
     use crate::{
         stream::channel::{strategy::forward::*, Channel},
+        tests::Item,
         timer,
     };
     use kompact::prelude::Component;
     use std::{sync::Arc, thread, time, time::UNIX_EPOCH};
-
-    #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1, keys = id)]
-    pub struct Item {
-        #[prost(uint64, tag = "1")]
-        id: u64,
-        #[prost(uint32, tag = "2")]
-        price: u32,
-    }
 
     // helper functions
     fn window_assigner_test_setup(

--- a/execution-plane/arcon/src/stream/source/socket.rs
+++ b/execution-plane/arcon/src/stream/source/socket.rs
@@ -190,6 +190,8 @@ mod tests {
         // Our example data struct for this test case.
         // add arcon_decoder to decode from String
         #[arcon_decoder(,)]
+        #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+        #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
         #[arcon(unsafe_ser_id = 500, reliable_ser_id = 501, version = 1)]
         pub struct ExtractorStruct {
             #[prost(uint32, tag = "1")]

--- a/execution-plane/arcon/src/test/recovery_tests.rs
+++ b/execution-plane/arcon/src/test/recovery_tests.rs
@@ -14,6 +14,8 @@ use std::{
 };
 use tempfile::NamedTempFile;
 
+#[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
 #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
 pub struct NormaliseElements {
     #[prost(int64, repeated, tag = "1")]

--- a/execution-plane/arcon/src/test/recovery_tests.rs
+++ b/execution-plane/arcon/src/test/recovery_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::{macros::*, prelude::*, timer};
+use crate::{prelude::*, timer};
 use once_cell::sync::Lazy;
 use std::{
     any::TypeId,

--- a/execution-plane/arcon/tests/basic_pipeline_tests.rs
+++ b/execution-plane/arcon/tests/basic_pipeline_tests.rs
@@ -7,7 +7,7 @@
 #![allow(bare_trait_objects)]
 extern crate arcon;
 
-use arcon::{macros::*, prelude::*, timer};
+use arcon::{prelude::*, timer};
 use std::{
     fs::File,
     io::{BufRead, BufReader},

--- a/execution-plane/arcon/tests/basic_pipeline_tests.rs
+++ b/execution-plane/arcon/tests/basic_pipeline_tests.rs
@@ -14,12 +14,16 @@ use std::{
 };
 use tempfile::NamedTempFile;
 
+#[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(arcon::Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
 #[arcon(unsafe_ser_id = 100, reliable_ser_id = 101, version = 1)]
 pub struct NormaliseElements {
     #[prost(int64, repeated, tag = "1")]
     pub data: Vec<i64>,
 }
 
+#[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(arcon::Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
 #[arcon(unsafe_ser_id = 98, reliable_ser_id = 99, version = 1)]
 pub struct SourceData {
     #[prost(int64, tag = "1")]


### PR DESCRIPTION
This PR adds the following (closes #102):

1. an Arcon derive macro that is more elegant and less hacky than its predecessor.
2.  ``proto_tests`` crate that verifies Protobuf files can be generated into valid ArconType's.

For number 2, it is at the moment not possible to generate Protobuf messages with ``oneof's`` while not specifying any specific ``key``. This is due to the ``oneof`` being an Option and it will therefore not implement ``Hash``. However, this should be resolved when we fix key extraction (#75).