### PR TITLE
add get_key method to ArconType and proto doc derive support

### DIFF
--- a/execution-plane/Cargo.lock
+++ b/execution-plane/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tui",
+ "twox-hash",
  "uuid",
  "x86",
 ]
@@ -2606,6 +2607,15 @@ dependencies = [
  "log",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
+dependencies = [
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/execution-plane/arcon/Cargo.toml
+++ b/execution-plane/arcon/Cargo.toml
@@ -38,6 +38,7 @@ itertools = "0.8.2"
 smallbox = { version = "0.8", features = ["coerce"] }
 cfg-if = "0.1.10"
 fxhash = "0.2.1"
+twox-hash = "1.5.0"
 crossbeam-utils = "0.7"
 num_cpus = "1.0"
 hocon = {version = "0.3", default-features = false, features = ["serde-support"]}
@@ -107,4 +108,8 @@ harness = false
 
 [[bench]]
 name = "flight_serde"
+harness = false
+
+[[bench]]
+name = "hash"
 harness = false

--- a/execution-plane/arcon/arcon_macros/src/lib.rs
+++ b/execution-plane/arcon/arcon_macros/src/lib.rs
@@ -140,34 +140,28 @@ fn hashable_fields(s: &syn::DataStruct) -> Vec<String> {
             Some(ref ident) => {
                 if let syn::Type::Path(p) = &field.ty {
                     for segment in &p.path.segments {
-                        let ref inner_ident = segment.ident;
-                        let cleaned = inner_ident.to_string();
-                        if cleaned == STRING_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == U32_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == U64_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == I32_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == I64_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == BOOL_IDENT {
-                            fields.push(ident.to_string());
-                        } else if cleaned == VEC_IDENT {
-                            if let syn::PathArguments::AngleBracketed(ag) = &segment.arguments {
-                                for a in ag.args.iter() {
-                                    if let syn::GenericArgument::Type(t) = a {
-                                        if let syn::Type::Path(tp) = t {
-                                            for s in &tp.path.segments {
-                                                if s.ident == U8_IDENT {
-                                                    fields.push(ident.to_string());
+                        let ref inner_ident = segment.ident.to_string();
+                        match inner_ident.as_str() {
+                            STRING_IDENT | U32_IDENT | U64_IDENT | I32_IDENT | I64_IDENT
+                            | BOOL_IDENT => {
+                                fields.push(ident.to_string());
+                            }
+                            VEC_IDENT => {
+                                if let syn::PathArguments::AngleBracketed(ag) = &segment.arguments {
+                                    for a in ag.args.iter() {
+                                        if let syn::GenericArgument::Type(t) = a {
+                                            if let syn::Type::Path(tp) = t {
+                                                for s in &tp.path.segments {
+                                                    if s.ident == U8_IDENT {
+                                                        fields.push(ident.to_string());
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
                             }
+                            _ => (),
                         }
                     }
                 }
@@ -188,34 +182,44 @@ fn bytes_estimation(s: &syn::DataStruct, fields: Vec<String>) -> usize {
                 if fields.contains(&ident.to_string()) {
                     if let syn::Type::Path(p) = &field.ty {
                         for segment in &p.path.segments {
-                            let ref ident = segment.ident;
-                            let cleaned = ident.to_string();
-                            if cleaned == STRING_IDENT {
-                                bytes += STRING_BYTES_ESTIMATION;
-                            } else if cleaned == U32_IDENT {
-                                bytes += std::mem::size_of::<u32>();
-                            } else if cleaned == U64_IDENT {
-                                bytes += std::mem::size_of::<u64>();
-                            } else if cleaned == I32_IDENT {
-                                bytes += std::mem::size_of::<i32>();
-                            } else if cleaned == I64_IDENT {
-                                bytes += std::mem::size_of::<i64>();
-                            } else if cleaned == BOOL_IDENT {
-                                bytes += std::mem::size_of::<bool>();
-                            } else if cleaned == VEC_IDENT {
-                                if let syn::PathArguments::AngleBracketed(ag) = &segment.arguments {
-                                    for a in ag.args.iter() {
-                                        if let syn::GenericArgument::Type(t) = a {
-                                            if let syn::Type::Path(tp) = t {
-                                                for s in &tp.path.segments {
-                                                    if s.ident == U8_IDENT {
-                                                        bytes += BYTE_ARRAY_ESTIMATION;
+                            let ref inner_ident = segment.ident.to_string();
+                            match inner_ident.as_str() {
+                                STRING_IDENT => {
+                                    bytes += STRING_BYTES_ESTIMATION;
+                                }
+                                U32_IDENT => {
+                                    bytes += std::mem::size_of::<u32>();
+                                }
+                                U64_IDENT => {
+                                    bytes += std::mem::size_of::<u64>();
+                                }
+                                I32_IDENT => {
+                                    bytes += std::mem::size_of::<i32>();
+                                }
+                                I64_IDENT => {
+                                    bytes += std::mem::size_of::<i64>();
+                                }
+                                BOOL_IDENT => {
+                                    bytes += std::mem::size_of::<bool>();
+                                }
+                                VEC_IDENT => {
+                                    if let syn::PathArguments::AngleBracketed(ag) =
+                                        &segment.arguments
+                                    {
+                                        for a in ag.args.iter() {
+                                            if let syn::GenericArgument::Type(t) = a {
+                                                if let syn::Type::Path(tp) = t {
+                                                    for s in &tp.path.segments {
+                                                        if s.ident == U8_IDENT {
+                                                            bytes += BYTE_ARRAY_ESTIMATION;
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
                                     }
                                 }
+                                _ => (),
                             }
                         }
                     }

--- a/execution-plane/arcon/arcon_macros/src/lib.rs
+++ b/execution-plane/arcon/arcon_macros/src/lib.rs
@@ -14,6 +14,20 @@ use proc_macro2::{Ident, Span};
 use quote::ToTokens;
 use syn::{parse_macro_input, DeriveInput};
 
+/// An estimation of how many bytes a string contains
+const STRING_BYTES_ESTIMATION: usize = 10;
+/// An estimation of how many bytes a byte array contains
+const BYTE_ARRAY_ESTIMATION: usize = 10;
+
+const STRING_IDENT: &str = "String";
+const VEC_IDENT: &str = "Vec";
+const U8_IDENT: &str = "u8";
+const U32_IDENT: &str = "u32";
+const U64_IDENT: &str = "u64";
+const I32_IDENT: &str = "i32";
+const I64_IDENT: &str = "i64";
+const BOOL_IDENT: &str = "bool";
+
 /// Derive macro for defining an Arcon supported struct
 ///
 /// ```rust,ignore
@@ -82,32 +96,31 @@ pub fn arcon(input: TokenStream) -> TokenStream {
     );
 
     let mut ids: Vec<proc_macro2::TokenStream> = Vec::with_capacity(3);
-    ids.push(quote! { const RELIABLE_SER_ID: SerId  = #reliable_ser_id; });
-    ids.push(quote! { const UNSAFE_SER_ID: SerId = #unsafe_ser_id; });
-    ids.push(quote! { const VERSION_ID: VersionId = #version; });
+    ids.push(quote! { const RELIABLE_SER_ID: ::arcon::SerId  = #reliable_ser_id; });
+    ids.push(quote! { const UNSAFE_SER_ID: ::arcon::SerId = #unsafe_ser_id; });
+    ids.push(quote! { const VERSION_ID: ::arcon::VersionId = #version; });
 
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let mut key_quote = {
-        if let Some(keys) = keys {
-            let keys_vec = keys.trim().split(',').map(|s| s.to_string()).collect();
-            Some(hash_fields(keys_vec))
-        } else {
-            None
-        }
-    };
+    let key_quote: proc_macro2::TokenStream;
 
     if let syn::Data::Struct(ref s) = input.data {
-        // If no keys attr was given, use all valid fields of the struct instead..
-        if key_quote.is_none() {
+        if let Some(keys) = keys {
+            // keys were specified...
+            let fields: Vec<String> = keys.trim().split(',').map(|s| s.to_string()).collect();
+            let estimated_bytes = bytes_estimation(s, fields.clone());
+            let hasher_quote = hasher_stream(estimated_bytes);
+            key_quote = hash_fields_stream(fields, hasher_quote);
+        } else {
+            // If no keys attr was given, use all valid fields of the struct instead..
             let mut fields = Vec::new();
             for field in s.fields.iter() {
                 match field.ident {
                     Some(ref ident) => {
                         let mut ignore = false;
                         // NOTE: ignore attempting to hash on Vec and Option values
-                        // 
+                        //
                         // Generated Option's may not have Hash implemented
                         if let syn::Type::Path(p) = &field.ty {
                             for segment in &p.path.segments {
@@ -126,22 +139,26 @@ pub fn arcon(input: TokenStream) -> TokenStream {
                     None => panic!("Struct missing identiy"),
                 }
             }
-            key_quote = Some(hash_fields(fields));
+
+            let estimated_bytes = bytes_estimation(s, fields.clone());
+            let hasher_quote = hasher_stream(estimated_bytes);
+            key_quote = hash_fields_stream(fields, hasher_quote);
         }
     } else if let syn::Data::Enum(..) = input.data {
-        if key_quote.is_some() {
+        if keys.is_some() {
             panic!("Hashing keys only work for structs");
         }
-        key_quote = Some(quote! { 0 }); // make get_key return 0
+        key_quote = quote! { 0 }; // make get_key return 0
     } else {
         panic!("#[derive(Arcon)] only works for structs/enums");
     }
 
     let output: proc_macro2::TokenStream = {
         quote! {
-            impl #impl_generics ArconType for #name #ty_generics #where_clause {
+            impl #impl_generics ::arcon::ArconType for #name #ty_generics #where_clause {
                 #(#ids)*
 
+                #[inline]
                 fn get_key(&self) -> u64 {
                     #key_quote
                 }
@@ -152,10 +169,79 @@ pub fn arcon(input: TokenStream) -> TokenStream {
     proc_macro::TokenStream::from(output)
 }
 
+/// Estimate the required bytes for hashing a struct given the selected `fields`
+fn bytes_estimation(s: &syn::DataStruct, fields: Vec<String>) -> usize {
+    let mut bytes = 0;
+    for field in s.fields.iter() {
+        match field.ident {
+            Some(ref ident) => {
+                if fields.contains(&ident.to_string()) {
+                    if let syn::Type::Path(p) = &field.ty {
+                        for segment in &p.path.segments {
+                            let ref ident = segment.ident;
+                            let cleaned = ident.to_string();
+                            if cleaned == STRING_IDENT {
+                                bytes += STRING_BYTES_ESTIMATION;
+                            } else if cleaned == U32_IDENT {
+                                bytes += std::mem::size_of::<u32>();
+                            } else if cleaned == U64_IDENT {
+                                bytes += std::mem::size_of::<u64>();
+                            } else if cleaned == I32_IDENT {
+                                bytes += std::mem::size_of::<i32>();
+                            } else if cleaned == I64_IDENT {
+                                bytes += std::mem::size_of::<i64>();
+                            } else if cleaned == BOOL_IDENT {
+                                bytes += std::mem::size_of::<bool>();
+                            } else if cleaned == VEC_IDENT {
+                                if let syn::PathArguments::AngleBracketed(ag) = &segment.arguments {
+                                    for a in ag.args.iter() {
+                                        if let syn::GenericArgument::Type(t) = a {
+                                            if let syn::Type::Path(tp) = t {
+                                                for s in &tp.path.segments {
+                                                    if s.ident == U8_IDENT {
+                                                        bytes += BYTE_ARRAY_ESTIMATION;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            None => panic!("Struct missing identiy"),
+        }
+    }
+
+    bytes
+}
+
+/// Return a TokenStream with a Hasher implementation based on the estimated bytes
+fn hasher_stream(estimated_bytes: usize) -> proc_macro2::TokenStream {
+    // Selection Process:
+    //
+    // Low bytes estimation: Pick a hasher suited for small values
+    // Medium bytes estimation: Pick Rust's default hasher
+    // High bytes estimation: Pick XXHash that performs much better on larger values
+
+    if estimated_bytes <= 8 {
+        quote! { ::arcon::FxHasher::default(); }
+    } else if estimated_bytes <= 32 {
+        quote! { ::std::collections::hash_map::DefaultHasher::new(); }
+    } else {
+        quote! { ::arcon::XxHash64::default(); }
+    }
+}
+
 /// Return the body of a function that hashes on a number of fields
 ///
 /// The output of the function is a key in the form of a [u64].
-fn hash_fields(keys: Vec<String>) -> proc_macro2::TokenStream {
+fn hash_fields_stream(
+    keys: Vec<String>,
+    hasher: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     let keys: Vec<proc_macro2::TokenStream> = keys
         .into_iter()
         .map(|k| {
@@ -166,7 +252,7 @@ fn hash_fields(keys: Vec<String>) -> proc_macro2::TokenStream {
 
     quote! {
         use ::std::hash::{Hash, Hasher};
-        let mut state = ::std::collections::hash_map::DefaultHasher::new();
+        let mut state = #hasher
         #(#keys)*
         state.finish()
     }

--- a/execution-plane/arcon/benches/hash.rs
+++ b/execution-plane/arcon/benches/hash.rs
@@ -69,6 +69,7 @@ impl LargerKey {
 
 impl Hash for LargerKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
         self.date.hash(state);
         self.name.hash(state);
         self.some_bytes.hash(state);

--- a/execution-plane/arcon/benches/hash.rs
+++ b/execution-plane/arcon/benches/hash.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2020, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+extern crate arcon;
+
+use crate::arcon::ArconType;
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
+#[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(arcon::Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
+#[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = "id")]
+pub struct SmallKey {
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    #[prost(uint32, tag = "2")]
+    pub price: u32,
+}
+
+impl SmallKey {
+    pub fn new() -> SmallKey {
+        SmallKey { id: 10, price: 10 }
+    }
+}
+
+impl Hash for SmallKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(arcon::Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
+#[arcon(
+    unsafe_ser_id = 104,
+    reliable_ser_id = 105,
+    version = 1,
+    keys = "id, date,name,some_bytes,raw_msg,timestamp"
+)]
+pub struct LargerKey {
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    #[prost(string, tag = "2")]
+    pub date: String,
+    #[prost(string, tag = "3")]
+    pub name: String,
+    #[prost(bytes, tag = "4")]
+    pub some_bytes: Vec<u8>,
+    #[prost(bytes, tag = "5")]
+    pub raw_msg: Vec<u8>,
+    #[prost(uint64, tag = "6")]
+    pub timestamp: u64,
+}
+impl LargerKey {
+    pub fn new() -> LargerKey {
+        LargerKey {
+            id: 10,
+            date: String::from("2020-02-10"),
+            name: String::from("Andersson"),
+            some_bytes: vec![0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1],
+            raw_msg: vec![0, 1, 0, 0, 1, 0, 0, 1],
+            timestamp: 12312839213821,
+        }
+    }
+}
+
+impl Hash for LargerKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.date.hash(state);
+        self.name.hash(state);
+        self.some_bytes.hash(state);
+        self.raw_msg.hash(state);
+        self.timestamp.hash(state);
+    }
+}
+
+fn arcon_hash(c: &mut Criterion) {
+    let mut group = c.benchmark_group("arcon_hash");
+    group.bench_function("arcon_small_key", arcon_small_key);
+    group.bench_function("DefaultHasher small key", rust_default_small_key);
+
+    group.bench_function("arcon_larger_key", arcon_larger_key);
+    group.bench_function("DefaultHasher larger key", rust_default_larger_key);
+
+    group.finish()
+}
+
+fn arcon_small_key(b: &mut Bencher) {
+    let basic = SmallKey::new();
+    b.iter(|| basic.get_key());
+}
+fn rust_default_small_key(b: &mut Bencher) {
+    let basic = SmallKey::new();
+    b.iter(|| {
+        let mut state = DefaultHasher::new();
+        basic.hash(&mut state);
+        state.finish()
+    });
+}
+
+fn arcon_larger_key(b: &mut Bencher) {
+    let large = LargerKey::new();
+    b.iter(|| large.get_key());
+}
+
+fn rust_default_larger_key(b: &mut Bencher) {
+    let large = LargerKey::new();
+    b.iter(|| {
+        let mut state = DefaultHasher::new();
+        large.hash(&mut state);
+        state.finish()
+    });
+}
+
+criterion_group!(benches, arcon_hash);
+criterion_main!(benches);

--- a/execution-plane/arcon/experiments/src/nexmark/mod.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/mod.rs
@@ -9,7 +9,6 @@ pub mod queries;
 pub mod sink;
 pub mod source;
 
-use arcon::prelude::*;
 use config::NEXMarkConfig;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};

--- a/execution-plane/arcon/experiments/src/nexmark/mod.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/mod.rs
@@ -291,7 +291,7 @@ impl NEXMarkEvent {
     }
 }
 
-#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation, Hash)]
+#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation)]
 pub enum Event {
     #[prost(message, tag = "1")]
     Person(Person),

--- a/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
+++ b/execution-plane/arcon/experiments/src/nexmark/queries/q3.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 //      AND open_auction.itemid = item.id
 //      AND item.categoryId = 10;
 
-#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation, Hash)]
+#[derive(prost::Oneof, Serialize, Deserialize, Clone, abomonation_derive::Abomonation)]
 enum PersonOrAuctionInner {
     #[prost(message, tag = "1")]
     Person(Person),

--- a/execution-plane/arcon/proto_tests/Cargo.toml
+++ b/execution-plane/arcon/proto_tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 arcon_serde = ["arcon/arcon_serde"]
 
 [dependencies]
-arcon = { path = "../" }
+arcon = { path = "../", features = ["arcon_serde"]}
 serde = { version = "1.0.104", features = ["derive"] }
 abomonation = "0.7.3"
 abomonation_derive = "0.5.0"

--- a/execution-plane/arcon/proto_tests/build.rs
+++ b/execution-plane/arcon/proto_tests/build.rs
@@ -5,7 +5,6 @@ extern crate cfg_if;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut basic_v3_cfg = prost_cfg();
-    basic_v3_cfg.type_attribute(".", &arcon_attr(104, 105, 1));
 
     basic_v3_cfg
         .compile_protos(&["src/basic_v3.proto"], &["src/"])
@@ -27,11 +26,4 @@ fn prost_cfg() -> prost_build::Config {
     );
 
     config
-}
-
-fn arcon_attr(unsafe_ser_id: usize, reliable_ser_id: usize, version: usize) -> String {
-    format!(
-        "#[arcon(unsafe_ser_id = {}, reliable_ser_id = {}, version = {})]",
-        unsafe_ser_id, reliable_ser_id, version
-    )
 }

--- a/execution-plane/arcon/proto_tests/src/basic_v3.proto
+++ b/execution-plane/arcon/proto_tests/src/basic_v3.proto
@@ -5,20 +5,38 @@ syntax = "proto3";
 
 package arcon_basic_v3;
 
+// unsafe_ser_id = 100
+// reliable_ser_id = 101
+// version = 1
+message Hello {
+  string id = 1;
+}
+
+// unsafe_ser_id = 102
+// reliable_ser_id = 103
+// version = 1
+// keys = query,page_number
 message SearchRequest {
   string query = 1;
   int32 page_number = 2;
   int32 result_per_page = 3;
+  Hello hello = 4;
+  repeated string msgs = 5;
 }
 
+// unsafe_ser_id = 104
+// reliable_ser_id = 105
+// version = 1
 message SearchBatch {
   repeated SearchRequest requests = 1;
   string id = 2;
 }
 
+// unsafe_ser_id = 106
+// reliable_ser_id = 107
+// version = 1
 message NestedMessage {
   repeated SearchBatch batches = 1;
   bytes raw_bytes = 2;
+  string id = 3;
 }
-
-// TODO: add more with oneof etc..

--- a/execution-plane/arcon/proto_tests/src/lib.rs
+++ b/execution-plane/arcon/proto_tests/src/lib.rs
@@ -6,6 +6,5 @@
 //! NOTE: Only Protobuf version 3 is being tested at the moment.
 
 pub mod basic_v3 {
-    use arcon::*;
     include!(concat!(env!("OUT_DIR"), "/arcon_basic_v3.rs"));
 }

--- a/execution-plane/arcon/src/data/mod.rs
+++ b/execution-plane/arcon/src/data/mod.rs
@@ -20,12 +20,12 @@ use std::{
 };
 
 pub trait ArconTypeBoundsNoSerde:
-    Clone + fmt::Debug + Hash + Sync + Send + PMessage + Default + Abomonation + 'static
+    Clone + fmt::Debug + Sync + Send + PMessage + Default + Abomonation + 'static
 {
 }
 
 impl<T> ArconTypeBoundsNoSerde for T where
-    T: Clone + fmt::Debug + Hash + Sync + Send + PMessage + Default + Abomonation + 'static
+    T: Clone + fmt::Debug + Sync + Send + PMessage + Default + Abomonation + 'static
 {
 }
 
@@ -53,6 +53,9 @@ where
     const RELIABLE_SER_ID: SerId;
     /// Current version of this ArconType
     const VERSION_ID: VersionId;
+
+    /// Return the key of this ArconType
+    fn get_key(&self) -> u64;
 }
 
 /// An Enum containing all possible stream events that may occur in an execution
@@ -267,46 +270,81 @@ impl Into<u32> for NodeID {
     }
 }
 
-// Implement ArconType for all data types that are supported
+// Implement ArconType for primitives.
+// NOTE: This is mainly for testing and development. In practice,
+// an ArconType is always a struct or enum.
+
 impl ArconType for u32 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U32_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for u64 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U64_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for i32 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I32_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for i64 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I64_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for ArconF32 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F32_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for ArconF64 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F64_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for bool {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_BOOLEAN_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_BOOLEAN_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
 }
 impl ArconType for String {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_STRING_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_STRING_ID;
     const VERSION_ID: VersionId = 1;
+
+    fn get_key(&self) -> u64 {
+        calc_hash(self)
+    }
+}
+
+fn calc_hash<T: std::hash::Hash>(t: &T) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
 }
 
 /// Float wrapper for f32 in order to impl Hash [std::hash::Hash]
@@ -422,6 +460,9 @@ impl ArconType for ArconNever {
     const UNSAFE_SER_ID: SerId = ser_id::NEVER_ID;
     const RELIABLE_SER_ID: SerId = ser_id::NEVER_ID;
     const VERSION_ID: VersionId = 1;
+    fn get_key(&self) -> u64 {
+        0
+    }
 }
 impl fmt::Debug for ArconNever {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -9,17 +9,23 @@
 
 #![feature(unboxed_closures)]
 
+// Enable use of arcon_macros within this crate
+extern crate self as arcon;
 #[cfg_attr(test, macro_use)]
 extern crate arcon_macros;
 #[doc(hidden)]
 pub use arcon_macros::*;
 
+
 // Imports below are exposed for #[derive(Arcon)]
 pub use crate::data::{ArconType, VersionId};
 pub use kompact::prelude::SerId;
+pub use fxhash::FxHasher;
+pub use twox_hash::XxHash64;
 
 #[macro_use]
 extern crate arcon_error as error;
+
 
 // Public Interface
 

--- a/execution-plane/arcon/src/lib.rs
+++ b/execution-plane/arcon/src/lib.rs
@@ -129,7 +129,6 @@ pub mod prelude {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use std::collections::hash_map::DefaultHasher;
 
     #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
@@ -139,22 +138,5 @@ pub(crate) mod tests {
         pub id: u64,
         #[prost(uint32, tag = "2")]
         pub price: u32,
-    }
-
-    #[test]
-    fn arcon_key_test() {
-        let i1 = Item { id: 1, price: 20 };
-        let i2 = Item { id: 2, price: 150 };
-        let i3 = Item { id: 1, price: 50 };
-
-        assert_eq!(calc_hash(&i1), calc_hash(&i3));
-        assert_ne!(calc_hash(&i1), calc_hash(&i2));
-    }
-
-    fn calc_hash<T: std::hash::Hash>(t: &T) -> u64 {
-        use std::hash::Hasher;
-        let mut s = DefaultHasher::new();
-        t.hash(&mut s);
-        s.finish()
     }
 }

--- a/execution-plane/arcon/src/stream/channel/strategy/mod.rs
+++ b/execution-plane/arcon/src/stream/channel/strategy/mod.rs
@@ -97,10 +97,6 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    use crate::data::VersionId;
-    use kompact::prelude::SerId;
-
     #[cfg_attr(feature = "arcon_serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
     #[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]

--- a/execution-plane/arcon/src/stream/source/socket.rs
+++ b/execution-plane/arcon/src/stream/source/socket.rs
@@ -115,9 +115,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        data::ArconType,
         pipeline::ArconPipeline,
-        prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map, SerId, VersionId},
+        prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map},
         state_backend::{in_memory::InMemory, StateBackend},
         timer,
     };


### PR DESCRIPTION
Adds a get key method on ArconType:

```rust
pub trait ArconType: ArconTypeBounds
where
    Self: std::marker::Sized,
{
    /// Return the key of this ArconType
    fn get_key(&self) -> u64;
}
```

The struct down below:
```rust
#[derive(Arcon, prost::Message, Clone, abomonation_derive::Abomonation)]
#[arcon(unsafe_ser_id = 104, reliable_ser_id = 105, version = 1, keys = "id")]
pub struct Item {
   #[prost(uint64, tag = "1")]
   pub id: u64,
   #[prost(uint32, tag = "2")]
   pub price: u32,
}
```

will implement ``get_key`` as following:

```rust
fn get_key(&self) -> u64 {
   let mut state = ::std::collections::hash_map::DefaultHasher::new();
   self.id.hash(&mut state);
   state.finish()
}
```

It now also works to derive the arcon attributes from the Protobuf files (if the #[arcon(..)] attr is not found, it will attempt to parse them from the doc comments). The proto definition below will implement the same get_key function as above.
```proto
// unsafe_ser_id = 104
// reliable_ser_id = 105
// version = 1
// keys = id
message Item {
  uint64 id = 1;
  uint32 price = 2;
}
```