### PR TITLE
Don't use WAL in state backends

### DIFF
--- a/execution-plane/Cargo.lock
+++ b/execution-plane/Cargo.lock
@@ -103,7 +103,6 @@ dependencies = [
  "tui",
  "twox-hash",
  "uuid",
- "x86",
 ]
 
 [[package]]
@@ -298,12 +297,6 @@ dependencies = [
  "shlex",
  "which 2.0.1",
 ]
-
-[[package]]
-name = "bit_field"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a165d606cf084741d4ac3a28fb6e9b1eb0bd31f6cd999098cfddb0b2ab381dc0"
 
 [[package]]
 name = "bitfields"
@@ -2071,17 +2064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "7.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
-dependencies = [
- "bitflags",
- "cc",
- "rustc_version",
-]
-
-[[package]]
 name = "rayon"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,15 +2917,4 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "x86"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562a325e24826b5ce9bbc19ee0639356cc22f073129b652e62d86c2556a8d52"
-dependencies = [
- "bit_field",
- "bitflags",
- "raw-cpuid",
 ]

--- a/execution-plane/arcon/Cargo.toml
+++ b/execution-plane/arcon/Cargo.toml
@@ -75,9 +75,6 @@ ctrlc = { version = "3.1.3", features = ["termination"], optional = true }
 crossterm = { version = "0.17.1", optional = true }
 better-panic = {version = "0.2.0", optional = true }
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-x86 = {version = "0.31.0", optional = true }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 faster-rs = { version = "0.10.0", optional = true }
 

--- a/execution-plane/arcon/arcon_state/src/rocks/aggregator_ops.rs
+++ b/execution-plane/arcon/arcon_state/src/rocks/aggregator_ops.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 use crate::{
-    error::*, serialization::protobuf, Aggregator, AggregatorOps, AggregatorState, Handle, Metakey,
-    Rocks,
+    error::*, rocks::default_write_opts, serialization::protobuf, Aggregator, AggregatorOps,
+    AggregatorState, Handle, Metakey, Rocks,
 };
 use rocksdb::{merge_operator::MergeFn, MergeOperands};
 
@@ -55,7 +55,9 @@ impl AggregatorOps for Rocks {
         let cf = backend.get_cf_handle(handle.id)?;
         // See the make_aggregating_merge function in this module. Its result is set as the
         // merging operator for this state.
-        Ok(backend.db.merge_cf(cf, key, serialized)?)
+        Ok(backend
+            .db
+            .merge_cf_opt(cf, key, serialized, &default_write_opts())?)
     }
 }
 

--- a/execution-plane/arcon/arcon_state/src/rocks/map_ops.rs
+++ b/execution-plane/arcon/arcon_state/src/rocks/map_ops.rs
@@ -3,6 +3,7 @@
 use crate::{
     error::*,
     handles::BoxedIteratorOfResult,
+    rocks::default_write_opts,
     serialization::{fixed_bytes, protobuf},
     Handle, Key, MapOps, MapState, Metakey, Rocks, Value,
 };
@@ -81,7 +82,7 @@ impl MapOps for Rocks {
             wb.put_cf(cf, key, serialized)?;
         }
 
-        Ok(backend.db.write(wb)?)
+        Ok(backend.db.write_opt(wb, &default_write_opts())?)
     }
 
     fn map_remove<K: Key, V: Value, IK: Metakey, N: Metakey>(

--- a/execution-plane/arcon/arcon_state/src/rocks/reducer_ops.rs
+++ b/execution-plane/arcon/arcon_state/src/rocks/reducer_ops.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 use crate::{
-    error::*, serialization::protobuf, Handle, Metakey, Reducer, ReducerOps, ReducerState, Rocks,
-    Value,
+    error::*, rocks::default_write_opts, serialization::protobuf, Handle, Metakey, Reducer,
+    ReducerOps, ReducerState, Rocks, Value,
 };
 use rocksdb::{merge_operator::MergeFn, MergeOperands};
 
@@ -42,7 +42,9 @@ impl ReducerOps for Rocks {
         let cf = backend.get_cf_handle(handle.id)?;
         // See the make_reducer_merge function in this module. Its result is set as the merging
         // operator for this state.
-        Ok(backend.db.merge_cf(cf, key, serialized)?)
+        Ok(backend
+            .db
+            .merge_cf_opt(cf, key, serialized, &default_write_opts())?)
     }
 }
 

--- a/execution-plane/arcon/arcon_state/src/rocks/vec_ops.rs
+++ b/execution-plane/arcon/arcon_state/src/rocks/vec_ops.rs
@@ -3,6 +3,7 @@
 use crate::{
     error::*,
     handles::BoxedIteratorOfResult,
+    rocks::default_write_opts,
     serialization::{fixed_bytes, fixed_bytes::FixedBytes, protobuf},
     Handle, Metakey, Rocks, Value, VecOps, VecState,
 };
@@ -36,7 +37,9 @@ impl VecOps for Rocks {
         let cf = backend.get_cf_handle(handle.id)?;
         // See the vec_merge function in this module. It is set as the merge operator for every
         // vec state.
-        Ok(backend.db.merge_cf(cf, key, serialized)?)
+        Ok(backend
+            .db
+            .merge_cf_opt(cf, key, serialized, &default_write_opts())?)
     }
 
     fn vec_get<T: Value, IK: Metakey, N: Metakey>(
@@ -146,7 +149,9 @@ impl VecOps for Rocks {
         fixed_bytes::serialize_into(&mut serialized.as_mut_slice(), &len)?;
 
         let cf = backend.get_cf_handle(handle.id)?;
-        backend.db.merge_cf(cf, key, serialized)?;
+        backend
+            .db
+            .merge_cf_opt(cf, key, serialized, &default_write_opts())?;
 
         Ok(())
     }


### PR DESCRIPTION
This disables the usage of write-ahead-log in rocks state backend. 

Unfortunately, rocksdb doesn't have any global config to disable WAL - you have to do that separately for every write-like operation. I hope I didn't miss any. Now that I think of it, maybe setting `wal_dir` to `/dev/null` would work. Probably not, because rocks would like to create and remove files there and that would fail.

Neither FASTER nor sled use WALs, so there are no changes there.

Closes #112 