### PR TITLE
Make the dataflow graph a ref-counted ref-cell

### DIFF
--- a/src/dataflow/dfg.rs
+++ b/src/dataflow/dfg.rs
@@ -1,0 +1,72 @@
+use std::any::Any;
+
+/// A logical dataflow-graph.
+#[derive(Default)]
+pub struct DFG {
+    /// The graph is represented as a Vec for maximum space-efficiency.
+    /// This works since nodes are never deleted from the graph.
+    graph: Vec<DFGNode>,
+}
+
+impl DFG {
+    /// Inserts a [`DFGNode`] into the dataflow graph and returns a unique
+    /// identifier of it.
+    pub fn insert(&mut self, node: DFGNode) -> DFGNodeID {
+        let id = DFGNodeID(self.graph.len());
+        self.graph.push(node);
+        id
+    }
+
+    /// Returns a reference to the [`DFGNode`] associated to a [`DFGNodeID`].
+    pub fn get(&self, id: &DFGNodeID) -> &DFGNode {
+        self.graph.get(id.0).unwrap()
+    }
+}
+
+/// The ID of a [`DFGNode`] in the dataflow graph.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct DFGNodeID(usize);
+
+/// A logical node in the dataflow graph.
+pub struct DFGNode {
+    kind: DFGNodeKind,
+    /// Ingoing edges to a node.
+    ingoing: Vec<DFGNodeID>,
+    //     constructor: Box<dyn Fn(Vec<Box<dyn ChannelTrait>>) -> (Box<dyn ErasedNode>, Vec<Box<dyn ChannelTrait>>)>,
+}
+
+impl DFGNode {
+    pub fn new(kind: DFGNodeKind, ingoing: Vec<DFGNodeID>) -> Self {
+        Self { kind, ingoing }
+    }
+}
+
+// OP::IN OP::OUT
+pub enum DFGNodeKind {
+    Source(Box<dyn Any>),
+    Node(Box<dyn Any>),
+}
+
+#[test]
+fn create_dfg() {
+    use DFGNodeKind::*;
+    let mut dfg = DFG::default();
+
+    let node0 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![]));
+    let node1 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node0]));
+    let node2 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node0]));
+    let node3 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node1, node2]));
+
+    // Constructs the dataflow graph:
+    //
+    //        +-> node1 -+
+    //        |          |
+    // node0 -+          +-> node3
+    //        |          |
+    //        +-> node2 -+
+
+    assert_eq!(DFGNodeID(0), node0);
+    assert_eq!(DFGNodeID(1), node1);
+    assert_eq!(DFGNodeID(2), node2);
+    assert_eq!(DFGNodeID(3), node3);
+}

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 pub mod stream;
+pub mod dfg;

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -3,12 +3,12 @@
 
 use crate::{
     data::{ArconType, NodeID},
+    prelude::ChannelStrategy,
     stream::operator::Operator,
     util::SafelySendableFn,
 };
 use arcon_error::ArconResult;
 use arcon_state::index::ArconState;
-use crate::prelude::ChannelStrategy;
 use core::any::Any;
 use std::{collections::HashMap, marker::PhantomData};
 
@@ -52,7 +52,6 @@ pub enum DFGType {
 use crate::prelude::Map;
 
 pub type DFGNodeID = usize;
-
 
 pub struct Stream<IN: ArconType> {
     _marker: PhantomData<IN>,

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -17,7 +17,7 @@ pub trait ChannelTrait {
 }
 
 use downcast::*;
-downcast!(ChannelTrait);
+downcast!(dyn ChannelTrait);
 
 pub struct DFGNode {
     dfg_type: DFGType,
@@ -45,8 +45,8 @@ impl DFGNode {
 
 // OP::IN OP::OUT
 pub enum DFGType {
-    Source(Box<Any>),
-    Node(Box<Any>),
+    Source(Box<dyn Any>),
+    Node(Box<dyn Any>),
 }
 
 use crate::prelude::Map;


### PR DESCRIPTION
This is a minor PR which makes the dataflow graph graph a ref-counted ref-cell. I think this will be needed to make it possible for multiple operators to own and mutate the graph. In particular, this happens when streams are multiplexed or forked. For example:

```rust
let stream0 = Stream::new();
let stream1 = stream0.map(|x| x + 1);

let stream2 = stream1.filter(|x| x % 2 == 0); // Multiplex
let stream3 = stream1.filter(|x| x % 2 != 0); // Multiplex

let (stream4, stream5) = stream3.split(|x| x > 0); // Fork
```

One thing I am wondering is how we share the context among sources, but I suppose this can be solved if sources are all spawned from the same pipeline object.

```rust
let stream0 = pipeline.source(...);
let stream1 = pipeline.source(...);

let stream3 = stream0.union(stream2);
```