### PR TITLE
api updates

### DIFF
--- a/arcon_error/src/lib.rs
+++ b/arcon_error/src/lib.rs
@@ -82,6 +82,8 @@ impl From<ArconStateError> for Error {
 
 /// A Result type for Arcon related crates
 pub type ArconResult<T> = ::std::result::Result<T, crate::Error>;
+/// A Result type used by Arcon Operators
+pub type OperatorResult<T> = ::std::result::Result<T, ArconStateError>;
 
 pub trait ResultExt<T> {
     fn ctx(self, message: &str) -> ArconResult<T>;

--- a/arcon_state/src/backend/mod.rs
+++ b/arcon_state/src/backend/mod.rs
@@ -356,3 +356,9 @@ impl FromStr for BackendType {
         }
     }
 }
+
+impl Default for BackendType {
+    fn default() -> Self {
+        BackendType::Sled
+    }
+}

--- a/examples/collection.rs
+++ b/examples/collection.rs
@@ -1,0 +1,21 @@
+use arcon::prelude::*;
+
+fn state_map(x: u64, _: &mut ()) -> OperatorResult<u64> {
+    Ok(x)
+}
+
+fn main() {
+    // TODO: Actually make this build the specified pipeline
+    let pipeline = Pipeline::default()
+        .collection((0..100).collect::<Vec<u64>>())
+        .filter(Box::new(|x: &u64| *x > 50))
+        .map_with_state(state_map, Box::new(|| ()), |conf| {
+            conf.set_backend(BackendType::Sled);
+            conf.set_state_id("map_state");
+        })
+        .build();
+
+    pipeline.start();
+
+    pipeline.await_termination();
+}

--- a/src/data/flight_serde.rs
+++ b/src/data/flight_serde.rs
@@ -291,7 +291,7 @@ mod test {
     where
         ReceivingType: ArconType,
     {
-        let pipeline = Pipeline::new();
+        let pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let (local, remote) = get_systems();
         let timeout = Duration::from_millis(150);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -510,7 +510,7 @@ impl Default for ArconNever {
     }
 }
 
-/// Variant of [Writer](bytes::buf::ext::Writer) for trait objects
+/// Variant of [Writer](bytes::buf::Writer) for trait objects
 pub struct BufMutWriter<'a> {
     buf: &'a mut dyn BufMut,
 }

--- a/src/dataflow/dfg.rs
+++ b/src/dataflow/dfg.rs
@@ -1,3 +1,5 @@
+use crate::manager::state::StateID;
+use arcon_state::BackendType;
 use std::any::Any;
 
 /// A logical dataflow-graph.
@@ -21,6 +23,11 @@ impl DFG {
     pub fn get(&self, id: &DFGNodeID) -> &DFGNode {
         self.graph.get(id.0).unwrap()
     }
+
+    /// Returns a mutable reference to the [`DFGNode`] associated to a [`DFGNodeID`].
+    pub fn get_mut(&mut self, id: &DFGNodeID) -> &mut DFGNode {
+        self.graph.get_mut(id.0).unwrap()
+    }
 }
 
 /// The ID of a [`DFGNode`] in the dataflow graph.
@@ -32,16 +39,36 @@ pub struct DFGNode {
     kind: DFGNodeKind,
     /// Ingoing edges to a node.
     ingoing: Vec<DFGNodeID>,
-    //     constructor: Box<dyn Fn(Vec<Box<dyn ChannelTrait>>) -> (Box<dyn ErasedNode>, Vec<Box<dyn ChannelTrait>>)>,
+    /// State Backend type to use for this DFG Node
+    ///
+    /// Default backend is Sled
+    backend_type: BackendType,
+    /// State ID for this DFG node
+    ///
+    /// Default ID is a random generated one
+    state_id: StateID,
+    // TODO: constructor
 }
 
 impl DFGNode {
     pub fn new(kind: DFGNodeKind, ingoing: Vec<DFGNodeID>) -> Self {
-        Self { kind, ingoing }
+        Self {
+            kind,
+            ingoing,
+            backend_type: Default::default(),
+            state_id: String::from("FIXME"),
+        }
+    }
+    /// Modifies the [`BackendType`] of this logical DFGNode
+    pub fn set_backend_type(&mut self, backend_type: BackendType) {
+        self.backend_type = backend_type;
+    }
+    /// Modifies the [`StateID`] of this logical DFGNode
+    pub fn set_state_id(&mut self, state_id: StateID) {
+        self.state_id = state_id;
     }
 }
 
-// OP::IN OP::OUT
 pub enum DFGNodeKind {
     Source(Box<dyn Any>),
     Node(Box<dyn Any>),

--- a/src/dataflow/dfg.rs
+++ b/src/dataflow/dfg.rs
@@ -3,6 +3,7 @@ use arcon_state::BackendType;
 use std::any::Any;
 
 /// A logical dataflow-graph.
+#[allow(dead_code)]
 #[derive(Default)]
 pub struct DFG {
     /// The graph is represented as a Vec for maximum space-efficiency.
@@ -23,22 +24,14 @@ impl DFG {
     pub fn get(&self, id: &DFGNodeID) -> &DFGNode {
         self.graph.get(id.0).unwrap()
     }
-
-    /// Returns a mutable reference to the [`DFGNode`] associated to a [`DFGNodeID`].
-    pub fn get_mut(&mut self, id: &DFGNodeID) -> &mut DFGNode {
-        self.graph.get_mut(id.0).unwrap()
-    }
 }
 
 /// The ID of a [`DFGNode`] in the dataflow graph.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct DFGNodeID(usize);
 
-/// A logical node in the dataflow graph.
-pub struct DFGNode {
-    kind: DFGNodeKind,
-    /// Ingoing edges to a node.
-    ingoing: Vec<DFGNodeID>,
+#[derive(Debug)]
+pub struct OperatorConfig {
     /// State Backend type to use for this DFG Node
     ///
     /// Default backend is Sled
@@ -47,25 +40,48 @@ pub struct DFGNode {
     ///
     /// Default ID is a random generated one
     state_id: StateID,
+}
+
+impl OperatorConfig {
+    /// Modifies the [`BackendType`] of this logical DFGNode
+    pub fn set_backend(&mut self, backend_type: BackendType) {
+        self.backend_type = backend_type;
+    }
+    /// Modifies the [`StateID`] of this logical DFGNode
+    pub fn set_state_id<I: Into<StateID>>(&mut self, i: I) {
+        self.state_id = i.into();
+    }
+}
+
+impl Default for OperatorConfig {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "rocksdb")]
+            backend_type: BackendType::Rocks,
+            #[cfg(not(feature = "rocksdb"))]
+            backend_type: Default::default(),
+            state_id: format!("op_{}", uuid::Uuid::new_v4().to_string()),
+        }
+    }
+}
+
+/// A logical node in the dataflow graph.
+#[allow(dead_code)]
+pub struct DFGNode {
+    kind: DFGNodeKind,
+    /// Ingoing edges to a node.
+    ingoing: Vec<DFGNodeID>,
+    config: OperatorConfig,
     // TODO: constructor
 }
 
 impl DFGNode {
-    pub fn new(kind: DFGNodeKind, ingoing: Vec<DFGNodeID>) -> Self {
+    pub fn new(kind: DFGNodeKind, config: OperatorConfig, ingoing: Vec<DFGNodeID>) -> Self {
         Self {
             kind,
             ingoing,
-            backend_type: Default::default(),
-            state_id: String::from("FIXME"),
+            config,
         }
-    }
-    /// Modifies the [`BackendType`] of this logical DFGNode
-    pub fn set_backend_type(&mut self, backend_type: BackendType) {
-        self.backend_type = backend_type;
-    }
-    /// Modifies the [`StateID`] of this logical DFGNode
-    pub fn set_state_id(&mut self, state_id: StateID) {
-        self.state_id = state_id;
     }
 }
 
@@ -79,10 +95,26 @@ fn create_dfg() {
     use DFGNodeKind::*;
     let mut dfg = DFG::default();
 
-    let node0 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![]));
-    let node1 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node0]));
-    let node2 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node0]));
-    let node3 = dfg.insert(DFGNode::new(Node(Box::new(())), vec![node1, node2]));
+    let node0 = dfg.insert(DFGNode::new(
+        Node(Box::new(())),
+        OperatorConfig::default(),
+        vec![],
+    ));
+    let node1 = dfg.insert(DFGNode::new(
+        Node(Box::new(())),
+        OperatorConfig::default(),
+        vec![node0],
+    ));
+    let node2 = dfg.insert(DFGNode::new(
+        Node(Box::new(())),
+        OperatorConfig::default(),
+        vec![node0],
+    ));
+    let node3 = dfg.insert(DFGNode::new(
+        Node(Box::new(())),
+        OperatorConfig::default(),
+        vec![node1, node2],
+    ));
 
     // Constructs the dataflow graph:
     //

--- a/src/dataflow/mod.rs
+++ b/src/dataflow/mod.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pub mod stream;
+/// Logical Dataflow Graph
 pub mod dfg;
+/// High-level Stream type that users may perform a series of transformations on
+pub mod stream;

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -245,27 +245,3 @@ impl<IN: ArconType> Stream<IN> {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn just_testing_things() {
-        fn state_map(x: u64, _: &mut ()) -> OperatorResult<u64> {
-            Ok(x)
-        }
-
-        // TODO: Actually make this build the specified pipeline
-        let pipeline = Pipeline::default()
-            .from_collection((0..10).collect::<Vec<u64>>())
-            .filter(Box::new(|x: &u64| *x > 5))
-            .map_with_state(state_map, Box::new(|| ()), |conf| {
-                conf.set_backend(BackendType::Sled);
-                conf.set_state_id("map_state");
-            })
-            .build();
-
-        pipeline.shutdown();
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub mod prelude {
         flight_serde::{reliable_remote::ReliableSerde, unsafe_remote::UnsafeSerde, FlightSerde},
         *,
     };
-    pub use arcon_error::{arcon_err, arcon_err_kind, ArconResult};
+    pub use arcon_error::{arcon_err, arcon_err_kind, ArconResult, OperatorResult};
 
     pub use kompact::{default_components::*, prelude::*};
     #[cfg(feature = "thread_pinning")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub mod pipeline;
 mod buffer;
 /// Arcon data types, serialisers/deserialisers
 mod data;
+/// Dataflow API
+mod dataflow;
 /// Module containing different runtime managers
 mod manager;
 #[cfg(feature = "metrics")]
@@ -51,8 +53,6 @@ mod stream;
 mod test;
 /// Internal Arcon Utilities
 mod util;
-/// Dataflow API
-mod dataflow;
 
 /// A module containing test utilities such as a global Arcon Allocator
 #[cfg(test)]
@@ -76,6 +76,7 @@ pub mod prelude {
         buffer::event::{BufferPool, BufferReader, BufferWriter, PoolInfo},
         conf::ArconConf,
         data::VersionId,
+        manager::state::StateID,
         pipeline::Pipeline,
         stream::{
             channel::{
@@ -111,8 +112,8 @@ pub mod prelude {
     pub use arcon_state as state;
 
     pub use arcon_state::{
-        AggregatorState, Appender, ArconState, Backend, BackendNever, EagerAppender, Handle,
-        MapState, ReducerState, Sled, Value, ValueState, VecState,
+        AggregatorState, Appender, ArconState, Backend, BackendNever, BackendType, EagerAppender,
+        Handle, MapState, ReducerState, Sled, Value, ValueState, VecState,
     };
 
     #[cfg(feature = "rayon")]

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -191,7 +191,8 @@ impl Pipeline {
         unimplemented!();
     }
 
-    pub fn from_collection<I, A>(self, i: I) -> Stream<A>
+    /// Creates a bounded data source using a Vector of [`ArconType`]
+    pub fn collection<I, A>(self, i: I) -> Stream<A>
     where
         I: Into<Vec<A>>,
         A: ArconType,

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -16,6 +16,8 @@ use arcon_allocator::Allocator;
 use kompact::{component::AbstractComponent, prelude::KompactSystem};
 use std::sync::{Arc, Mutex};
 
+pub use crate::dataflow::stream::Stream;
+
 #[derive(Clone)]
 pub struct Pipeline {
     /// [kompact] system that drives the execution of components
@@ -40,7 +42,7 @@ impl Default for Pipeline {
 
 /// A Node with operator type, state backend type, and timer type erased
 pub type DynamicNode<IN> = Box<dyn CreateErased<ArconMessage<IN>>>;
-/// Result of creating a [`DynamicNode`] in a [`KompactSystem`](kompact::KompactSystem)
+/// Result of creating a [`DynamicNode`] in a [`KompactSystem`](kompact::prelude::KompactSystem)
 pub type CreatedDynamicNode<IN> = Arc<dyn AbstractComponent<Message = ArconMessage<IN>>>;
 /// A Source with operator type, state backend type, and timer type erased
 pub type DynamicSource = Box<dyn CreateErased<()>>;

--- a/src/stream/channel/mod.rs
+++ b/src/stream/channel/mod.rs
@@ -7,7 +7,6 @@ pub mod strategy;
 use crate::data::{flight_serde::FlightSerde, ArconMessage, ArconType};
 use kompact::prelude::{ActorPath, ActorRefStrong};
 
-
 /// A Channel represents a connection to another Component
 #[derive(Clone)]
 pub enum Channel<A: ArconType> {

--- a/src/stream/channel/strategy/broadcast.rs
+++ b/src/stream/channel/strategy/broadcast.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn broadcast_local_test() {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/channel/strategy/forward.rs
+++ b/src/stream/channel/strategy/forward.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn forward_test() {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/channel/strategy/key_by.rs
+++ b/src/stream/channel/strategy/key_by.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn keyby_test() {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/channel/strategy/mod.rs
+++ b/src/stream/channel/strategy/mod.rs
@@ -17,8 +17,7 @@ pub mod round_robin;
 
 use crate::dataflow::stream::ChannelTrait;
 
-impl<A: ArconType> ChannelTrait for ChannelStrategy<A> {
-}
+impl<A: ArconType> ChannelTrait for ChannelStrategy<A> {}
 
 /// A `ChannelStrategy` defines a strategy of how messages are sent downstream
 ///

--- a/src/stream/channel/strategy/round_robin.rs
+++ b/src/stream/channel/strategy/round_robin.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn round_robin_local_test() {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/node/mod.rs
+++ b/src/stream/node/mod.rs
@@ -525,7 +525,7 @@ mod tests {
     fn node_test_setup() -> (ActorRef<ArconMessage<i32>>, Arc<Component<DebugNode<i32>>>) {
         // Returns a filter Node with input channels: sender1..sender3
         // And a debug sink receiving its results
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = &pipeline.system();
 

--- a/src/stream/operator/function/filter.rs
+++ b/src/stream/operator/function/filter.rs
@@ -69,7 +69,7 @@ where
         &mut self,
         element: ArconElement<IN>,
         mut ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         if (self.udf)(&element.data, &mut self.state) {
             ctx.output(element);
         }

--- a/src/stream/operator/function/map.rs
+++ b/src/stream/operator/function/map.rs
@@ -15,24 +15,24 @@ pub struct Map<IN, OUT, F, S>
 where
     IN: ArconType,
     OUT: ArconType,
-    F: SafelySendableFn(IN, &mut S) -> ArconResult<OUT>,
+    F: SafelySendableFn(IN, &mut S) -> OperatorResult<OUT>,
     S: ArconState,
 {
     state: S,
     udf: F,
-    _marker: PhantomData<fn(IN) -> ArconResult<OUT>>,
+    _marker: PhantomData<fn(IN) -> OperatorResult<OUT>>,
 }
 
-impl<IN, OUT> Map<IN, OUT, fn(IN, &mut ()) -> ArconResult<OUT>, ()>
+impl<IN, OUT> Map<IN, OUT, fn(IN, &mut ()) -> OperatorResult<OUT>, ()>
 where
     IN: ArconType,
     OUT: ArconType,
 {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        udf: impl SafelySendableFn(IN) -> ArconResult<OUT>,
-    ) -> Map<IN, OUT, impl SafelySendableFn(IN, &mut ()) -> ArconResult<OUT>, ()> {
-        let udf = move |input: IN, _: &mut ()| udf(input);
+        udf: impl SafelySendableFn(IN) -> OUT,
+    ) -> Map<IN, OUT, impl SafelySendableFn(IN, &mut ()) -> OperatorResult<OUT>, ()> {
+        let udf = move |input: IN, _: &mut ()| Ok(udf(input));
         Map {
             state: (),
             udf,
@@ -45,7 +45,7 @@ impl<IN, OUT, F, S> Map<IN, OUT, F, S>
 where
     IN: ArconType,
     OUT: ArconType,
-    F: SafelySendableFn(IN, &mut S) -> ArconResult<OUT>,
+    F: SafelySendableFn(IN, &mut S) -> OperatorResult<OUT>,
     S: ArconState,
 {
     pub fn stateful(state: S, udf: F) -> Self {
@@ -61,7 +61,7 @@ impl<IN, OUT, F, S> Operator for Map<IN, OUT, F, S>
 where
     IN: ArconType,
     OUT: ArconType,
-    F: SafelySendableFn(IN, &mut S) -> ArconResult<OUT>,
+    F: SafelySendableFn(IN, &mut S) -> OperatorResult<OUT>,
     S: ArconState,
 {
     type IN = IN;
@@ -73,7 +73,7 @@ where
         &mut self,
         element: ArconElement<IN>,
         mut ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         ctx.output(ArconElement {
             data: (self.udf)(element.data, &mut self.state)?,
             timestamp: element.timestamp,

--- a/src/stream/operator/function/map_in_place.rs
+++ b/src/stream/operator/function/map_in_place.rs
@@ -14,23 +14,23 @@ use std::marker::PhantomData;
 pub struct MapInPlace<IN, F, S>
 where
     IN: ArconType,
-    F: SafelySendableFn(&mut IN, &mut S) -> ArconResult<()>,
+    F: SafelySendableFn(&mut IN, &mut S) -> OperatorResult<()>,
     S: ArconState,
 {
     state: S,
     udf: F,
-    _marker: PhantomData<fn(&mut IN) -> ArconResult<()>>,
+    _marker: PhantomData<fn(&mut IN) -> OperatorResult<()>>,
 }
 
-impl<IN> MapInPlace<IN, fn(&mut IN, &mut ()) -> ArconResult<()>, ()>
+impl<IN> MapInPlace<IN, fn(&mut IN, &mut ()) -> OperatorResult<()>, ()>
 where
     IN: ArconType,
 {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        udf: impl SafelySendableFn(&mut IN) -> ArconResult<()>,
-    ) -> MapInPlace<IN, impl SafelySendableFn(&mut IN, &mut ()) -> ArconResult<()>, ()> {
-        let udf = move |input: &mut IN, _: &mut ()| udf(input);
+        udf: impl SafelySendableFn(&mut IN),
+    ) -> MapInPlace<IN, impl SafelySendableFn(&mut IN, &mut ()) -> OperatorResult<()>, ()> {
+        let udf = move |input: &mut IN, _: &mut ()| Ok(udf(input));
         MapInPlace {
             state: (),
             udf,
@@ -42,7 +42,7 @@ where
 impl<IN, F, S> MapInPlace<IN, F, S>
 where
     IN: ArconType,
-    F: SafelySendableFn(&mut IN, &mut S) -> ArconResult<()>,
+    F: SafelySendableFn(&mut IN, &mut S) -> OperatorResult<()>,
     S: ArconState,
 {
     pub fn stateful(state: S, udf: F) -> Self {
@@ -57,7 +57,7 @@ where
 impl<IN, F, S> Operator for MapInPlace<IN, F, S>
 where
     IN: ArconType,
-    F: SafelySendableFn(&mut IN, &mut S) -> ArconResult<()>,
+    F: SafelySendableFn(&mut IN, &mut S) -> OperatorResult<()>,
     S: ArconState,
 {
     type IN = IN;
@@ -69,7 +69,7 @@ where
         &mut self,
         element: ArconElement<IN>,
         mut ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         let mut elem = element;
         (self.udf)(&mut elem.data, &mut self.state)?;
         ctx.output(elem);

--- a/src/stream/operator/mod.rs
+++ b/src/stream/operator/mod.rs
@@ -36,17 +36,17 @@ pub trait Operator: Send + Sized {
         &mut self,
         element: ArconElement<Self::IN>,
         ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()>;
+    ) -> OperatorResult<()>;
 
     /// Determines how the `Operator` handles timeouts it registered earlier when they are triggered
     fn handle_timeout(
         &mut self,
         timeout: Self::TimerState,
         ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()>;
+    ) -> OperatorResult<()>;
 
     /// Determines how the `Operator` persists its state
-    fn persist(&mut self) -> Result<(), arcon_state::error::ArconStateError>;
+    fn persist(&mut self) -> OperatorResult<()>;
 }
 
 /// Helper macro to implement an empty ´handle_timeout` function
@@ -57,7 +57,7 @@ macro_rules! ignore_timeout {
             &mut self,
             _timeout: Self::TimerState,
             _ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-        ) -> ArconResult<()> {
+        ) -> OperatorResult<()> {
             Ok(())
         }
     };
@@ -67,7 +67,7 @@ macro_rules! ignore_timeout {
 #[macro_export]
 macro_rules! ignore_persist {
     () => {
-        fn persist(&mut self) -> Result<(), arcon_state::error::ArconStateError> {
+        fn persist(&mut self) -> OperatorResult<()> {
             Ok(())
         }
     };

--- a/src/stream/operator/sink/local_file.rs
+++ b/src/stream/operator/sink/local_file.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::{prelude::*, stream::operator::OperatorContext};
+use arcon_error::OperatorResult;
 use std::{
     cell::RefCell,
     fs::{File, OpenOptions},
@@ -52,7 +53,7 @@ where
         &mut self,
         element: ArconElement<IN>,
         _ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         if let Err(err) = writeln!(self.file.borrow_mut(), "{:?}", element.data) {
             eprintln!("Error while writing to file sink {}", err.to_string());
         }

--- a/src/stream/operator/sink/socket.rs
+++ b/src/stream/operator/sink/socket.rs
@@ -3,6 +3,7 @@
 
 use crate::prelude::*;
 use ::serde::Serialize;
+use arcon_error::OperatorResult;
 use bytes::Bytes;
 use futures::{channel, executor::block_on, SinkExt, StreamExt};
 use std::{
@@ -84,7 +85,7 @@ where
         &mut self,
         element: ArconElement<Self::IN>,
         _ctx: OperatorContext<Self, impl Backend, impl ComponentDefinition>,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         let mut tx = self.tx_channel.clone();
         let fmt_data = {
             if let Ok(mut json) = serde_json::to_string(&element.data) {

--- a/src/stream/source/collection.rs
+++ b/src/stream/source/collection.rs
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn collection_source_test() {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/source/local_file.rs
+++ b/src/stream/source/local_file.rs
@@ -114,7 +114,6 @@ mod tests {
         pipeline::Pipeline,
         prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map, NodeID},
     };
-    use arcon_error::ArconResult;
     use std::{io::prelude::*, sync::Arc, thread, time};
     use tempfile::NamedTempFile;
 
@@ -159,11 +158,6 @@ mod tests {
         let channel_strategy =
             ChannelStrategy::Forward(Forward::new(channel, NodeID::new(1), pool_info));
 
-        // just pass it on
-        fn map_fn(x: ArconF64) -> ArconResult<ArconF64> {
-            Ok(x)
-        }
-
         // Set up SourceContext
         let watermark_interval = 25;
         let backend = std::sync::Arc::new(crate::util::temp_backend());
@@ -172,7 +166,7 @@ mod tests {
             watermark_interval,
             None, // no timestamp extractor
             channel_strategy,
-            Map::new(&map_fn),
+            Map::new(Box::new(|x: ArconF64| x)),
             backend,
         );
 

--- a/src/stream/source/local_file.rs
+++ b/src/stream/source/local_file.rs
@@ -123,7 +123,7 @@ mod tests {
     }
 
     fn test_setup<A: ArconType>() -> (Pipeline, Arc<Component<DebugNode<A>>>) {
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let system = pipeline.system();
         let sink = system.create(move || {
             let s: DebugNode<A> = DebugNode::new();

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     util::SafelySendableFn,
 };
-use arcon_error::ArconResult;
+use arcon_error::OperatorResult;
 use kompact::prelude::ComponentDefinition;
 use std::sync::Arc;
 
@@ -120,7 +120,7 @@ where
         &mut self,
         data: ArconElement<OP::IN>,
         source: &impl ComponentDefinition,
-    ) -> ArconResult<()> {
+    ) -> OperatorResult<()> {
         self.operator.handle_element(
             data,
             OperatorContext::<_, B, _>::new(source, &mut None, &mut self.channel_strategy),

--- a/src/stream/source/socket.rs
+++ b/src/stream/source/socket.rs
@@ -156,7 +156,7 @@ mod tests {
         let addr = "127.0.0.1:4001".parse().unwrap();
 
         // Setup
-        let mut pipeline = Pipeline::new();
+        let mut pipeline = Pipeline::default();
         let pool_info = pipeline.get_pool_info();
         let system = pipeline.system();
 

--- a/src/stream/source/socket.rs
+++ b/src/stream/source/socket.rs
@@ -129,7 +129,6 @@ mod tests {
         pipeline::Pipeline,
         prelude::{Channel, ChannelStrategy, DebugNode, Forward, Map},
     };
-    use arcon_error::ArconResult;
     use std::{sync::Arc, thread, time};
     use tokio::{net::TcpStream, prelude::*, runtime::Runtime};
 
@@ -176,8 +175,8 @@ mod tests {
             ChannelStrategy::Forward(Forward::new(Channel::Local(sink_ref), 1.into(), pool_info));
 
         // just pass it on
-        fn map_fn(x: ExtractorStruct) -> ArconResult<ExtractorStruct> {
-            Ok(x)
+        fn map_fn(x: ExtractorStruct) -> ExtractorStruct {
+            x
         }
 
         // Set up SourceContext

--- a/src/test/poc.rs
+++ b/src/test/poc.rs
@@ -193,7 +193,7 @@ fn poc_test() {
         .wait_timeout(std::time::Duration::from_millis(100))
         .expect("started");
 
-    pipeline.watch(&["map_state_one", "map_state_two"], batch_comp);
+    pipeline.watch(vec!["map_state_one", "map_state_two"], batch_comp);
 
     let node_ref = map_comp.actor_ref().hold().expect("fail");
 

--- a/src/test/poc.rs
+++ b/src/test/poc.rs
@@ -6,6 +6,7 @@ use crate::{
     prelude::*,
     stream::{node::NodeState, operator::function::Map},
 };
+use arcon_error::OperatorResult;
 use arcon_state::Sled;
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
@@ -96,7 +97,7 @@ fn poc_test() {
     let channel_strategy: ChannelStrategy<u32> =
         ChannelStrategy::Forward(Forward::new(channel, NodeID::new(0), pool_info.clone()));
 
-    fn map_fn_two(x: u32, state: &mut MapStateTwo<impl Backend>) -> ArconResult<u32> {
+    fn map_fn_two(x: u32, state: &mut MapStateTwo<impl Backend>) -> OperatorResult<u32> {
         state.rolling_counter().rmw(|v| {
             *v += 1;
         });
@@ -159,7 +160,7 @@ fn poc_test() {
         .wait_timeout(std::time::Duration::from_millis(100))
         .expect("started");
 
-    fn map_fn(x: u32, state: &mut MapStateOne<impl Backend>) -> ArconResult<u32> {
+    fn map_fn(x: u32, state: &mut MapStateOne<impl Backend>) -> OperatorResult<u32> {
         state.events().append(x)?;
         Ok(x * 2)
     }


### PR DESCRIPTION
Some updates:

*    Remove Rc<RefCell<...>> as it complicates things and there won't be support for forked/split graphs in the runtime for the 0.2.0 release anyways.
*   Add OperatorConfig and allow stateful operators to configure it through a closure. Noticed that with the current possible configurations, there is no point for stateless operators to configure anything.
*  Update stateless version of operators Map, Filter, Flatmap etc to not have to explicitly use Ok(...).
*  Update Operator to use OperatorResult.

Next step is to make the following code build the pipeline where all components have been connected...

```rust
use arcon::prelude::*;

fn state_map(x: u64, _: &mut ()) -> OperatorResult<u64> {
    Ok(x)
}

fn main() {
    // TODO: Actually make this build the specified pipeline
    let pipeline = Pipeline::default()
        .collection((0..100).collect::<Vec<u64>>())
        .filter(Box::new(|x: &u64| *x > 50))
        .map_with_state(state_map, Box::new(|| ()), |conf| {
            conf.set_backend(BackendType::Sled);
            conf.set_state_id("map_state");
        })
        .build();

    pipeline.start();

    pipeline.await_termination();
}
```