### PR TITLE
add Table module

### DIFF
--- a/arcon_macros/src/arrow.rs
+++ b/arcon_macros/src/arrow.rs
@@ -60,10 +60,10 @@ pub fn derive_arrow(input: TokenStream) -> TokenStream {
                         #(#builders)*
                         Ok(())
                     }
-                    fn arrow_table(capacity: usize) -> ::arcon::ArrowTable {
-                        let builder = ::arcon::StructBuilder::from_fields(#fields, capacity);
+                    fn table() -> ::arcon::MutableTable {
+                        let builder = ::arcon::StructBuilder::from_fields(#fields, ::arcon::RECORD_BATCH_SIZE);
                         let table_name = stringify!(#name).to_lowercase();
-                        ::arcon::ArrowTable::new(table_name, Self::schema(), builder)
+                        ::arcon::MutableTable::new(::arcon::RecordBatchBuilder::new(table_name, Self::schema(), builder))
                     }
                 }
             }

--- a/arcon_macros/src/state.rs
+++ b/arcon_macros/src/state.rs
@@ -65,11 +65,11 @@ pub fn derive_state(input: TokenStream) -> TokenStream {
         #[cfg(feature = "arcon_arrow")]
         let tables = quote! {
             #[inline]
-            fn tables(&mut self) -> Vec<::arcon::ArrowTable> {
+            fn tables(&mut self) -> Vec<::arcon::ImmutableTable> {
                 vec![#(#tables)*]
                     .into_iter()
                     .filter_map(|m| m)
-                    .collect::<Vec<::arcon::ArrowTable>>()
+                    .collect::<Vec<::arcon::ImmutableTable>>()
             }
             fn has_tables() -> bool {
                 #has_tables_quote
@@ -128,7 +128,7 @@ fn get_table(
             ..
         }) => {
             let quote = quote! {
-                match self.#ident.arrow_table() {
+                match self.#ident.table() {
                     Ok(table) => table.and_then(|mut t| { t.set_name(#table_name); Some(t)}),
                     Err(_) => None,
                 }

--- a/src/data/arrow.rs
+++ b/src/data/arrow.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2021, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use crate::table::MutableTable;
 use arrow::{
     array::{
         ArrayBuilder, BinaryBuilder, BooleanBuilder, Float32Builder, Float64Builder, Int32Builder,
@@ -8,10 +9,7 @@ use arrow::{
     },
     datatypes::{DataType, Schema},
     error::ArrowError,
-    record_batch::RecordBatch,
 };
-use datafusion::{datasource::MemTable, error::DataFusionError};
-use std::sync::Arc;
 
 /// Represents an Arcon type that can be converted to Arrow
 pub trait ToArrow {
@@ -48,8 +46,8 @@ to_arrow!(Vec<u8>, BinaryBuilder, DataType::Binary);
 pub trait ArrowOps: Sized {
     /// Return the Arrow Schema
     fn schema() -> Schema;
-    /// Creates an Empty ArrowTable
-    fn arrow_table(capacity: usize) -> ArrowTable;
+    /// Creates a new MutableTable
+    fn table() -> MutableTable;
     /// Used to append `self` to an Arrow StructBuilder
     fn append(self, builder: &mut StructBuilder) -> Result<(), ArrowError>;
 }
@@ -63,7 +61,7 @@ macro_rules! arrow_ops {
                     stringify!($type)
                 );
             }
-            fn arrow_table(_: usize) -> ArrowTable {
+            fn table() -> MutableTable {
                 unreachable!(
                     "ArrowOps not possible for single value {}",
                     stringify!($type)
@@ -89,100 +87,3 @@ arrow_ops!(f32);
 arrow_ops!(bool);
 arrow_ops!(String);
 arrow_ops!(Vec<u8>);
-
-#[derive(Debug)]
-pub struct ArrowTable {
-    table_name: String,
-    schema: Arc<Schema>,
-    builder: StructBuilder,
-}
-
-impl ArrowTable {
-    pub fn new(table_name: String, schema: Schema, builder: StructBuilder) -> Self {
-        Self {
-            table_name,
-            schema: Arc::new(schema),
-            builder,
-        }
-    }
-    pub fn load(
-        &mut self,
-        data: impl IntoIterator<Item = impl ArrowOps>,
-    ) -> Result<(), ArrowError> {
-        for value in data {
-            value.append(&mut self.builder)?;
-            self.builder.append(true)?;
-        }
-        Ok(())
-    }
-    pub fn name(&self) -> &str {
-        &self.table_name
-    }
-    pub fn len(&self) -> usize {
-        self.builder.len()
-    }
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-    pub fn schema(&self) -> Arc<Schema> {
-        self.schema.clone()
-    }
-    pub fn record_batch(&mut self) -> Result<RecordBatch, ArrowError> {
-        let columns = self.schema.fields().len();
-        let data_arr = self.builder.finish();
-        let mut arr = Vec::with_capacity(columns);
-        for i in 0..columns {
-            arr.push(data_arr.column(i).clone());
-        }
-        RecordBatch::try_new(self.schema(), arr)
-    }
-
-    pub fn mem_table(&mut self) -> Result<MemTable, DataFusionError> {
-        let record_batch = self.record_batch()?;
-        MemTable::try_new(self.schema(), vec![vec![record_batch]])
-    }
-    pub fn set_name(&mut self, name: &str) {
-        self.table_name = name.to_string();
-    }
-}
-
-impl<A: ArrowOps> From<Vec<A>> for ArrowTable {
-    fn from(input: Vec<A>) -> Self {
-        let mut table = A::arrow_table(input.len());
-        let _ = table.load(input);
-        table
-    }
-}
-
-// impl Send + Sync for ArrowTable
-unsafe impl Send for ArrowTable {}
-unsafe impl Sync for ArrowTable {}
-
-#[derive(Clone)]
-pub struct ImmutableTable {
-    name: String,
-    schema: Arc<Schema>,
-    batches: Vec<RecordBatch>,
-}
-
-impl ImmutableTable {
-    pub fn mem_table(self) -> Result<MemTable, DataFusionError> {
-        MemTable::try_new(self.schema, vec![self.batches])
-    }
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-    pub fn schema(&self) -> Arc<Schema> {
-        self.schema.clone()
-    }
-}
-
-impl From<ArrowTable> for ImmutableTable {
-    fn from(mut table: ArrowTable) -> Self {
-        Self {
-            name: table.name().to_string(),
-            schema: table.schema(),
-            batches: vec![table.record_batch().unwrap()],
-        }
-    }
-}

--- a/src/index/appender/eager.rs
+++ b/src/index/appender/eager.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::{AppenderIndex, IndexOps};
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, Handle},
@@ -50,7 +50,7 @@ where
         self.handle.set_item_key(key);
     }
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/appender/mod.rs
+++ b/src/index/appender/mod.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::{AppenderIndex, HashTable, IndexOps, IndexValue};
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{handles::ActiveHandle, Backend, VecState},
     error::*,
@@ -76,7 +76,7 @@ where
         self.current_key = key;
     }
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/hash_table/eager.rs
+++ b/src/index/hash_table/eager.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::IndexOps;
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, BoxedIteratorOfResult, Handle},
@@ -72,7 +72,7 @@ where
     }
     fn set_key(&mut self, _: u64) {}
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/hash_table/mod.rs
+++ b/src/index/hash_table/mod.rs
@@ -9,9 +9,9 @@ use std::{
     hash::{BuildHasher, Hash, Hasher},
 };
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::IndexOps;
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, Handle},
@@ -370,7 +370,7 @@ where
     }
     fn set_key(&mut self, _: u64) {}
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -16,7 +16,8 @@ use std::{borrow::Cow, sync::Arc};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "arcon_arrow")] {
-        use crate::data::arrow::{ArrowOps, ArrowTable};
+        use crate::data::arrow::ArrowOps;
+        use crate::table::ImmutableTable;
         pub trait IndexValue: Value + ArrowOps {}
         impl<T> IndexValue for T where T: Value + ArrowOps {}
     } else if #[cfg(not(feature = "arcon_arrow"))] {
@@ -41,9 +42,9 @@ pub trait IndexOps {
     /// Set the current active key for the index
     fn set_key(&mut self, key: u64);
 
-    /// Create an ArrowTable from the data in the Index
+    /// Create a [ImmutableTable] from the data in the Index
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>>;
+    fn table(&mut self) -> Result<Option<ImmutableTable>>;
 }
 
 /// A separate trait for defining a state constructor for [ArconState]
@@ -74,9 +75,9 @@ pub trait ArconState: StateConstructor + Send + 'static {
     fn persist(&mut self) -> Result<()>;
     fn set_key(&mut self, key: u64);
 
-    /// Returns a Vec of registered Arrow tables
+    /// Returns a Vec of registered tables
     #[cfg(feature = "arcon_arrow")]
-    fn tables(&mut self) -> Vec<ArrowTable>;
+    fn tables(&mut self) -> Vec<ImmutableTable>;
 
     #[cfg(feature = "arcon_arrow")]
     fn has_tables() -> bool;
@@ -95,7 +96,7 @@ impl ArconState for EmptyState {
     }
     fn set_key(&mut self, _: u64) {}
     #[cfg(feature = "arcon_arrow")]
-    fn tables(&mut self) -> Vec<ArrowTable> {
+    fn tables(&mut self) -> Vec<ImmutableTable> {
         Vec::new()
     }
     #[cfg(feature = "arcon_arrow")]
@@ -118,7 +119,7 @@ impl IndexOps for EmptyState {
         // ignore
     }
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/timer/mod.rs
+++ b/src/index/timer/mod.rs
@@ -3,7 +3,7 @@
 
 use super::{hash_table::eager::EagerHashTable, IndexOps};
 #[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, Handle},
@@ -225,7 +225,7 @@ where
     }
     fn set_key(&mut self, _: u64) {}
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/value/eager.rs
+++ b/src/index/value/eager.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::{IndexOps, IndexValue, ValueIndex};
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, Handle},
@@ -88,13 +88,15 @@ where
         self.current_key = key;
     }
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
-        let len = self.handle.len()?;
-        let mut table = V::arrow_table(len);
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
+        let mut table = V::table();
         let values = self.handle.values()?;
         table
             .load(values.filter_map(|v| v.ok()))
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
-        Ok(Some(table))
+        let imut = table
+            .to_immutable()
+            .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
+        Ok(Some(imut))
     }
 }

--- a/src/index/value/eager.rs
+++ b/src/index/value/eager.rs
@@ -95,7 +95,7 @@ where
             .load(values.filter_map(|v| v.ok()))
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
         let imut = table
-            .to_immutable()
+            .immutable()
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
         Ok(Some(imut))
     }

--- a/src/index/value/local.rs
+++ b/src/index/value/local.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
 use crate::index::{IndexOps, ValueIndex};
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use arcon_state::{
     backend::{
         handles::{ActiveHandle, Handle},
@@ -110,7 +110,7 @@ where
     }
     fn set_key(&mut self, _: u64) {}
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
         Ok(None)
     }
 }

--- a/src/index/value/mod.rs
+++ b/src/index/value/mod.rs
@@ -93,7 +93,7 @@ where
             .load(values.filter_map(|v| v.ok()))
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
         let imut = table
-            .to_immutable()
+            .immutable()
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
         Ok(Some(imut))
     }

--- a/src/index/value/mod.rs
+++ b/src/index/value/mod.rs
@@ -3,7 +3,7 @@
 
 use super::{HashTable, IndexOps, IndexValue, ValueIndex};
 #[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ArrowTable;
+use crate::table::ImmutableTable;
 use arcon_state::{error::*, Backend};
 use std::{borrow::Cow, sync::Arc};
 
@@ -86,13 +86,16 @@ where
     }
 
     #[cfg(feature = "arcon_arrow")]
-    fn arrow_table(&mut self) -> Result<Option<ArrowTable>> {
-        let (len, values) = self.hash_table.full_iter()?;
-        let mut table = V::arrow_table(len);
+    fn table(&mut self) -> Result<Option<ImmutableTable>> {
+        let (_, values) = self.hash_table.full_iter()?;
+        let mut table = V::table();
         table
             .load(values.filter_map(|v| v.ok()))
             .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
-        Ok(Some(table))
+        let imut = table
+            .to_immutable()
+            .map_err(|e| ArconStateError::Unknown { msg: e.to_string() })?;
+        Ok(Some(imut))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub use arcon_state::error::ArconStateError;
 // Imports below are exposed for #[derive(Arcon)]
 cfg_if::cfg_if! {
     if #[cfg(feature = "arcon_arrow")] {
-        pub use crate::data::arrow::{ArrowOps, ArrowTable, ToArrow};
+        pub use crate::data::arrow::{ArrowOps, ToArrow};
+        pub use crate::table::{RECORD_BATCH_SIZE, ImmutableTable, RecordBatchBuilder, MutableTable};
         pub use arrow::array::{ArrayBuilder, StringBuilder, PrimitiveBuilder, ArrayData, ArrayDataBuilder, StructArray, StructBuilder};
         pub use arrow::error::ArrowError;
         pub use arrow::datatypes::{DataType, Field, Schema};
@@ -91,6 +92,9 @@ mod metrics;
 mod pipeline;
 /// Contains the core stream logic
 mod stream;
+/// Table implementations
+#[cfg(feature = "arcon_arrow")]
+mod table;
 /// Test module containing some more complex unit tests
 #[cfg(test)]
 mod test;
@@ -166,7 +170,7 @@ pub mod prelude {
     pub use kompact::{get_core_ids, CoreId};
 
     #[cfg(feature = "arcon_arrow")]
-    pub use super::{Arrow, ArrowOps, ArrowTable, ToArrow};
+    pub use super::{Arrow, ArrowOps, MutableTable, ToArrow};
     #[cfg(feature = "arcon_arrow")]
     pub use datafusion::prelude::*;
 

--- a/src/manager/node.rs
+++ b/src/manager/node.rs
@@ -3,8 +3,6 @@
 
 #[cfg(feature = "arcon_arrow")]
 use crate::manager::query::{QueryManagerMsg, QueryManagerPort, TableRegistration};
-#[cfg(feature = "arcon_arrow")]
-use crate::table::ImmutableTable;
 use crate::{
     data::{ArconMessage, Epoch, NodeID, StateID, Watermark},
     index::{
@@ -296,10 +294,9 @@ where
                                         let mut state =
                                             OP::OperatorState::restore(snapshot.clone())?;
                                         for table in state.tables() {
-                                            let imut = ImmutableTable::from(table);
                                             let registration = TableRegistration {
                                                 epoch: epoch.epoch,
-                                                table: imut,
+                                                table,
                                             };
                                             self.query_manager_port.trigger(
                                                 QueryManagerMsg::TableRegistration(registration),

--- a/src/manager/node.rs
+++ b/src/manager/node.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 #[cfg(feature = "arcon_arrow")]
-use crate::data::arrow::ImmutableTable;
-#[cfg(feature = "arcon_arrow")]
-use crate::index::ArconState;
-#[cfg(feature = "arcon_arrow")]
 use crate::manager::query::{QueryManagerMsg, QueryManagerPort, TableRegistration};
+#[cfg(feature = "arcon_arrow")]
+use crate::table::ImmutableTable;
 use crate::{
     data::{ArconMessage, Epoch, NodeID, StateID, Watermark},
-    index::{HashTable, IndexOps, LocalValue, StateConstructor, ValueIndex, EMPTY_STATE_ID},
+    index::{
+        ArconState, HashTable, IndexOps, LocalValue, StateConstructor, ValueIndex, EMPTY_STATE_ID,
+    },
     manager::{
         epoch::EpochEvent,
         snapshot::{Snapshot, SnapshotEvent, SnapshotManagerPort},

--- a/src/manager/query.rs
+++ b/src/manager/query.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::data::arrow::ImmutableTable;
+use crate::table::ImmutableTable;
 use arrow::{datatypes::Schema, util::pretty::*};
 use datafusion::prelude::*;
 use kompact::prelude::*;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,0 +1,282 @@
+// Copyright (c) 2021, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use crate::data::arrow::ArrowOps;
+use arrow::{
+    array::{ArrayBuilder, StructBuilder},
+    datatypes::Schema,
+    error::ArrowError,
+    ipc::{
+        convert::*,
+        reader::read_record_batch,
+        writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions},
+    },
+    record_batch::RecordBatch,
+};
+use datafusion::{datasource::MemTable, error::DataFusionError};
+use std::sync::Arc;
+
+// Size for each RecordBatch in Arrow
+pub const RECORD_BATCH_SIZE: usize = 1024;
+
+/// A Mutable Append Only Table
+#[derive(Debug)]
+pub struct MutableTable {
+    /// Builder used to append data to the table
+    builder: RecordBatchBuilder,
+    /// Stores appended record batches
+    batches: Vec<RecordBatch>,
+}
+impl MutableTable {
+    /// Creates a new MutableTable
+    pub fn new(builder: RecordBatchBuilder) -> Self {
+        Self {
+            builder,
+            batches: Vec::new(),
+        }
+    }
+
+    /// Append a single element to the table
+    #[inline]
+    pub fn append(&mut self, elem: impl ArrowOps) -> Result<(), ArrowError> {
+        if self.builder.len() == RECORD_BATCH_SIZE {
+            let batch = self.builder.record_batch()?;
+            self.batches.push(batch);
+        }
+
+        self.builder.append(elem)?;
+        Ok(())
+    }
+    /// Load elements into the table from an Iterator
+    #[inline]
+    pub fn load(
+        &mut self,
+        elems: impl IntoIterator<Item = impl ArrowOps>,
+    ) -> Result<(), ArrowError> {
+        for elem in elems {
+            self.append(elem)?;
+        }
+        Ok(())
+    }
+
+    // internal helper to finish last batch
+    fn finish(&mut self) -> Result<(), ArrowError> {
+        if !self.builder.is_empty() {
+            let batch = self.builder.record_batch()?;
+            self.batches.push(batch);
+        }
+        Ok(())
+    }
+
+    /// Converts the MutableTable into an ImmutableTable
+    pub fn to_immutable(mut self) -> Result<ImmutableTable, ArrowError> {
+        self.finish()?;
+
+        Ok(ImmutableTable {
+            name: self.builder.name().to_string(),
+            schema: self.builder.schema(),
+            batches: self.batches,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct RecordBatchBuilder {
+    table_name: String,
+    schema: Arc<Schema>,
+    builder: StructBuilder,
+}
+
+impl RecordBatchBuilder {
+    pub fn new(table_name: String, schema: Schema, builder: StructBuilder) -> Self {
+        Self {
+            table_name,
+            schema: Arc::new(schema),
+            builder,
+        }
+    }
+    /// Append an Element to the table
+    #[inline]
+    pub fn append(&mut self, elem: impl ArrowOps) -> Result<(), ArrowError> {
+        elem.append(&mut self.builder)?;
+        self.builder.append(true)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.table_name
+    }
+    pub fn len(&self) -> usize {
+        self.builder.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+    pub fn record_batch(&mut self) -> Result<RecordBatch, ArrowError> {
+        let columns = self.schema.fields().len();
+        let data_arr = self.builder.finish();
+        let mut arr = Vec::with_capacity(columns);
+        for i in 0..columns {
+            arr.push(data_arr.column(i).clone());
+        }
+        RecordBatch::try_new(self.schema(), arr)
+    }
+
+    pub fn mem_table(&mut self) -> Result<MemTable, DataFusionError> {
+        let record_batch = self.record_batch()?;
+        MemTable::try_new(self.schema(), vec![vec![record_batch]])
+    }
+    pub fn set_name(&mut self, name: &str) {
+        self.table_name = name.to_string();
+    }
+}
+
+/// An Immutable Table
+#[derive(Clone)]
+pub struct ImmutableTable {
+    name: String,
+    schema: Arc<Schema>,
+    batches: Vec<RecordBatch>,
+}
+
+impl ImmutableTable {
+    /// Creates a Raw version of ImmutableTable that can be persisted to disk
+    /// or sent over the network.
+    pub fn raw_table(&self) -> Result<RawTable, ArrowError> {
+        let ipc = IpcDataGenerator::default();
+        let write_options = IpcWriteOptions::default();
+        let mut tracker = DictionaryTracker::new(false);
+
+        let encoded_data = ipc.schema_to_bytes(&*self.schema, &write_options);
+        let raw_schema = encoded_data.ipc_message;
+
+        let mut raw_batches: Vec<RawRecordBatch> = Vec::with_capacity(self.batches.len());
+
+        for batch in self.batches.iter() {
+            let (_, encoded_data) = ipc
+                .encoded_batch(&batch, &mut tracker, &write_options)
+                .map_err(|e| ArrowError::IoError(e.to_string()))?;
+
+            raw_batches.push(RawRecordBatch {
+                ipc_message: encoded_data.ipc_message,
+                arrow_data: encoded_data.arrow_data,
+            });
+        }
+
+        Ok(RawTable {
+            name: self.name.clone(),
+            schema: raw_schema,
+            batches: raw_batches,
+        })
+    }
+    pub fn mem_table(self) -> Result<MemTable, DataFusionError> {
+        MemTable::try_new(self.schema, vec![self.batches])
+    }
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+    pub fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
+    }
+    /// Restore a ImmutableTable from a RawTable
+    pub fn from_raw_table(table: RawTable) -> Result<Self, ArrowError> {
+        let s = schema_from_bytes(&table.schema).map_err(|e| ArrowError::IoError(e.to_string()))?;
+        let schema_ref = Arc::new(s);
+        let dict_fields = Vec::new();
+
+        let mut batches = Vec::with_capacity(table.batches.len());
+
+        for raw in table.batches {
+            let message = arrow::ipc::root_as_message(&raw.ipc_message)
+                .map_err(|e| ArrowError::IoError(e.to_string()))?;
+
+            match message.header_type() {
+                arrow::ipc::MessageHeader::RecordBatch => {
+                    if let Some(batch) = message.header_as_record_batch() {
+                        let record_batch = read_record_batch(
+                            &raw.arrow_data,
+                            batch,
+                            schema_ref.clone(),
+                            &dict_fields,
+                        )
+                        .map_err(|e| ArrowError::IoError(e.to_string()))?;
+                        batches.push(record_batch);
+                    } else {
+                        return Err(ArrowError::IoError(
+                            "Failed to match RecordBatch".to_string(),
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(ArrowError::IoError(
+                        "Matched unexpected ipc message".to_string(),
+                    ))
+                }
+            }
+        }
+
+        Ok(ImmutableTable {
+            name: table.name,
+            schema: schema_ref,
+            batches,
+        })
+    }
+}
+
+/// A Raw version of [ImmutableTable] that can be persisted to disk or sent over the wire.
+#[derive(prost::Message, Clone)]
+pub struct RawTable {
+    #[prost(string)]
+    pub name: String,
+    #[prost(bytes)]
+    pub schema: Vec<u8>,
+    #[prost(message, repeated)]
+    pub batches: Vec<RawRecordBatch>,
+}
+
+/// A Raw version of an Arrow RecordBatch
+#[derive(prost::Message, Clone)]
+pub struct RawRecordBatch {
+    #[prost(bytes)]
+    pub ipc_message: Vec<u8>,
+    #[prost(bytes)]
+    pub arrow_data: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ToArrow;
+    use datafusion::datasource::TableProvider;
+
+    #[derive(Arrow, Clone)]
+    pub struct Event {
+        pub id: u64,
+        pub data: f32,
+    }
+
+    #[test]
+    fn table_serde_test() {
+        let mut table = Event::table();
+        let events = 1548;
+        for i in 0..events {
+            let event = Event {
+                id: i as u64,
+                data: 1.0,
+            };
+            table.append(event).unwrap();
+        }
+
+        let immutable: ImmutableTable = table.to_immutable().unwrap();
+        let raw_table: RawTable = immutable.raw_table().unwrap();
+        let back_to_immutable: ImmutableTable = ImmutableTable::from_raw_table(raw_table).unwrap();
+        // create a mem table and check that we have correct number of rows...
+        let mem_table = back_to_immutable.mem_table().unwrap();
+        assert_eq!(mem_table.statistics().num_rows, Some(1548));
+    }
+}

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -69,7 +69,7 @@ impl MutableTable {
     }
 
     /// Converts the MutableTable into an ImmutableTable
-    pub fn to_immutable(mut self) -> Result<ImmutableTable, ArrowError> {
+    pub fn immutable(mut self) -> Result<ImmutableTable, ArrowError> {
         self.finish()?;
 
         Ok(ImmutableTable {
@@ -233,7 +233,7 @@ impl TryFrom<ImmutableTable> for RawTable {
         }
 
         Ok(RawTable {
-            name: table.name.clone(),
+            name: table.name,
             schema: raw_schema,
             batches: raw_batches,
         })
@@ -273,7 +273,7 @@ mod tests {
             table.append(event).unwrap();
         }
 
-        let immutable: ImmutableTable = table.to_immutable().unwrap();
+        let immutable: ImmutableTable = table.immutable().unwrap();
         let raw_table: RawTable = RawTable::try_from(immutable).unwrap();
         let back_to_immutable: ImmutableTable = ImmutableTable::try_from(raw_table).unwrap();
         // create a mem table and check that we have correct number of rows...


### PR DESCRIPTION
Split tables into:

* MutableTable
* ImmutableTable
* RawTable

Where ``ImmutableTable`` can be converted to a ``RawTable`` using Arrow ipc. We will now be able to persist partial or full tables to disk or send them over the wire.