### PR TITLE
Remove ArconUnit type

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -484,25 +484,6 @@ impl PartialEq for ArconF64 {
     }
 }
 
-/// A `Unit` compatible with `prost`. This is needed because `prost` throws an error when using the
-/// standard `()` type.
-#[cfg_attr(feature = "arcon_serde", derive(Serialize, Deserialize))]
-#[derive(Clone, PartialEq, Eq, prost::Message)]
-pub struct ArconUnit {}
-
-impl ArconType for ArconUnit {
-    #[cfg(feature = "unsafe_flight")]
-    const UNSAFE_SER_ID: SerId = ser_id::UNIT_ID;
-    const RELIABLE_SER_ID: SerId = ser_id::UNIT_ID;
-    const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        0
-    }
-}
-
-#[cfg(feature = "unsafe_flight")]
-impl Abomonation for ArconUnit {}
-
 /// Arcon variant of the `Never` (or `!`) type which fulfills `ArconType` requirements
 #[cfg_attr(feature = "arcon_serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq)]

--- a/src/data/ser_id.rs
+++ b/src/data/ser_id.rs
@@ -1,7 +1,5 @@
 use kompact::prelude::SerId;
 
-pub const UNIT_ID: SerId = 48;
-
 pub const NEVER_ID: SerId = 49;
 
 // Serialisation IDs for Arcon primitives

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub mod prelude {
     */
     pub use crate::{
         conf::ArconConf,
-        data::{ArconElement, ArconNever, ArconType, ArconUnit, StateID, VersionId},
+        data::{ArconElement, ArconNever, ArconType, StateID, VersionId},
         dataflow::conf::{
             OperatorBuilder, OperatorConf, ParallelismStrategy, SourceBuilder, SourceConf,
             StreamKind,


### PR DESCRIPTION
It appears like `ArconUnit` is not needed. Prost can handle messages containing `()` as long as they are have `#[prost(message, required)]`.