### PR TITLE
Add debug node to API

### DIFF
--- a/guide/examples/src/bin/collection.rs
+++ b/guide/examples/src/bin/collection.rs
@@ -2,21 +2,28 @@ use arcon::prelude::*;
 
 fn main() {
     let mut pipeline = Pipeline::default()
+        .with_debug_node()
         .collection((0..100).collect::<Vec<u64>>(), |conf| {
             conf.set_arcon_time(ArconTime::Event);
             conf.set_timestamp_extractor(|x: &u64| *x);
         })
         .operator(OperatorBuilder {
-            constructor: Arc::new(|_| Filter::new(|x| *x > 50)),
+            constructor: Arc::new(|_| Filter::new(|x: &u64| *x > 50)),
             conf: Default::default(),
         })
         .operator(OperatorBuilder {
             constructor: Arc::new(|_| Map::new(|x| x + 10)),
             conf: Default::default(),
         })
-        .to_console()
         .build();
 
     pipeline.start();
-    pipeline.await_termination();
+
+    std::thread::sleep(std::time::Duration::from_millis(5000));
+    let debug_node = pipeline.get_debug_node::<u64>().unwrap();
+
+    debug_node.on_definition(|cd| {
+        let sum: u64 = cd.data.iter().map(|elem| elem.data).sum();
+        assert_eq!(sum, 4165);
+    });
 }

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -315,7 +315,6 @@ mod tests {
         assert_eq!(conf.checkpoint_dir, PathBuf::from("/dev/null"));
         assert_eq!(conf.watermark_interval, 1000);
         // Check defaults
-        assert_eq!(conf.state_dir, state_dir_default());
         assert_eq!(conf.node_metrics_interval, node_metrics_interval_default());
         assert_eq!(conf.channel_batch_size, channel_batch_size_default());
         assert_eq!(conf.buffer_pool_size, buffer_pool_size_default());

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -204,13 +204,21 @@ fn execution_mode_default() -> ExecutionMode {
 }
 
 fn state_dir_default() -> PathBuf {
+    #[cfg(test)]
+    let mut res = tempfile::tempdir().unwrap().into_path();
+    #[cfg(not(test))]
     let mut res = std::env::temp_dir();
+
     res.push("arcon/live_states");
     res
 }
 
 fn checkpoint_dir_default() -> PathBuf {
+    #[cfg(test)]
+    let mut res = tempfile::tempdir().unwrap().into_path();
+    #[cfg(not(test))]
     let mut res = std::env::temp_dir();
+
     res.push("arcon/checkpoints");
     res
 }

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -81,6 +81,8 @@ impl<IN: ArconType> Stream<IN> {
     }
 
     /// Will make sure the most downstream Node will print its result to the console
+    ///
+    /// Note that if the Pipeline has been configured with a debug node, it will take precedence.
     #[allow(clippy::wrong_self_convention)]
     pub fn to_console(mut self) -> Stream<IN> {
         self.ctx.console_output = true;

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -9,7 +9,7 @@ use crate::{
         dfg::{ChannelKind, DFGNode, DFGNodeID, DFGNodeKind, DFG},
     },
     pipeline::{AssembledPipeline, Pipeline},
-    stream::operator::Operator,
+    stream::{node::debug::DebugNode, operator::Operator},
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -115,14 +115,27 @@ impl<IN: ArconType> Stream<IN> {
                     let (channel_kind, components) = {
                         match target_nodes {
                             Some(comps) => (dfg_node.channel_kind, comps),
-                            None => (
-                                if self.ctx.console_output {
-                                    ChannelKind::Console
-                                } else {
-                                    ChannelKind::Mute
-                                },
-                                vec![],
-                            ),
+                            None => {
+                                // At the end of the graph....
+                                if self.ctx.pipeline.debug_node_enabled() {
+                                    let node: DebugNode<IN> = DebugNode::new();
+                                    self.ctx.pipeline.create_debug_node(node);
+                                }
+
+                                match self.ctx.pipeline.abstract_debug_node {
+                                    Some(ref debug_node) => {
+                                        (ChannelKind::Forward, vec![debug_node.clone()])
+                                    }
+                                    None => (
+                                        if self.ctx.console_output {
+                                            ChannelKind::Console
+                                        } else {
+                                            ChannelKind::Mute
+                                        },
+                                        vec![],
+                                    ),
+                                }
+                            }
                         }
                     };
 

--- a/src/manager/epoch.rs
+++ b/src/manager/epoch.rs
@@ -66,6 +66,7 @@ impl EpochManager {
                     source_manager.tell(SourceEvent::Epoch(Epoch::new(self.next_epoch)));
                     self.next_epoch += 1;
                 } else {
+                    #[cfg(not(test))]
                     error!(self.ctx.log(), "SourceManager was never set");
                 }
                 Handled::Ok

--- a/src/pipeline/assembled.rs
+++ b/src/pipeline/assembled.rs
@@ -2,8 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::Pipeline;
-use crate::{index::ArconState, manager::snapshot::Snapshot, stream::node::source::SourceEvent};
-use kompact::{component::AbstractComponent, prelude::ActorRefFactory};
+use crate::{
+    data::ArconType,
+    index::ArconState,
+    manager::snapshot::Snapshot,
+    stream::node::{debug::DebugNode, source::SourceEvent},
+};
+use kompact::{
+    component::AbstractComponent,
+    prelude::{ActorRefFactory, Component},
+};
 use std::sync::{
     mpsc,
     mpsc::{Receiver, Sender},
@@ -55,6 +63,17 @@ impl AssembledPipeline {
         }
 
         self.start_flag = true;
+    }
+
+    /// Fetch [DebugNode] component of the [Pipeline]
+    ///
+    /// Returns `None` if the [Pipeline] was not configured with a [DebugNode].
+    /// Note that it is up to the user to make sure `A` is of correct type.
+    pub fn get_debug_node<A>(&self) -> Option<Arc<Component<DebugNode<A>>>>
+    where
+        A: ArconType,
+    {
+        self.pipeline.get_debug_node()
     }
 
     /// Awaits termination from the pipeline

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -4,9 +4,10 @@
 use crate::{
     buffer::event::PoolInfo,
     conf::{ArconConf, ExecutionMode},
+    data::ArconMessage,
     dataflow::{
         conf::{DefaultBackend, SourceBuilder, SourceConf},
-        constructor::source_manager_constructor,
+        constructor::{source_manager_constructor, ErasedComponent},
         dfg::*,
         stream::Context,
     },
@@ -18,7 +19,7 @@ use crate::{
     },
     prelude::*,
     stream::{
-        node::source::SourceEvent,
+        node::{debug::DebugNode, source::SourceEvent},
         source::{local_file::LocalFileSource, Source},
     },
 };
@@ -74,6 +75,12 @@ pub struct Pipeline {
     pub(crate) snapshot_manager: Arc<Component<SnapshotManager>>,
     endpoint_manager: Arc<Component<EndpointManager>>,
     pub(crate) query_manager: Arc<Component<QueryManager>>,
+    /// Flag indicating whether to spawn a debug node for the Pipeline
+    debug_node_flag: bool,
+    // Type erased Arc<Component<DebugNode<A>>>
+    pub(crate) debug_node: Option<ErasedComponent>,
+    // Type erased Arc<dyn AbstractComponent<Message = ArconMessage<A>>>
+    pub(crate) abstract_debug_node: Option<ErasedComponent>,
 }
 
 impl Default for Pipeline {
@@ -126,6 +133,9 @@ impl Pipeline {
             source_manager: None,
             endpoint_manager,
             query_manager,
+            debug_node_flag: false,
+            debug_node: None,
+            abstract_debug_node: None,
         }
     }
 
@@ -271,6 +281,11 @@ impl Pipeline {
         self.source(builder)
     }
 
+    pub fn with_debug_node(mut self) -> Self {
+        self.debug_node_flag = true;
+        self
+    }
+
     // Internal helper for creating PoolInfo for a ChannelStrategy
     pub(crate) fn get_pool_info(&self) -> PoolInfo {
         PoolInfo::new(
@@ -311,5 +326,41 @@ impl Pipeline {
                 "Only local reference supported for now. should really be an ActorPath later on"
             );
         }
+    }
+    pub fn debug_node_enabled(&self) -> bool {
+        self.debug_node_flag
+    }
+
+    // internal helper to create a DebugNode from a Stream object
+    pub(crate) fn create_debug_node<A>(&mut self, node: DebugNode<A>)
+    where
+        A: ArconType,
+    {
+        assert_ne!(
+            self.debug_node.is_some(),
+            true,
+            "DebugNode has already been created!"
+        );
+        let component = self.ctrl_system.create(|| node);
+
+        self.ctrl_system
+            .start_notify(&component)
+            .wait_timeout(std::time::Duration::from_millis(500))
+            .expect("DebugNode comp never started!");
+
+        self.debug_node = Some(component.clone());
+        // define abstract version of the component as the building phase needs it to downcast properly..
+        let comp: Arc<dyn AbstractComponent<Message = ArconMessage<A>>> = component;
+        self.abstract_debug_node = Some(Arc::new(comp) as ErasedComponent);
+    }
+
+    // internal helper to help fetch DebugNode from an AssembledPipeline
+    pub(crate) fn get_debug_node<A: ArconType>(&self) -> Option<Arc<Component<DebugNode<A>>>> {
+        self.debug_node.as_ref().map(|erased_comp| {
+            erased_comp
+                .clone()
+                .downcast::<Component<DebugNode<A>>>()
+                .unwrap()
+        })
     }
 }

--- a/src/stream/source/local_file.rs
+++ b/src/stream/source/local_file.rs
@@ -44,7 +44,7 @@ where
         match self.lines.next() {
             Some(Ok(line)) => match line.parse::<Self::Item>() {
                 Ok(record) => Poll::Ready(record),
-                Err(_) => Poll::Error("failed to parse line".to_string()),
+                Err(_) => Poll::Error("failed to parse line".to_string()), // todo
             },
             Some(Err(err)) => Poll::Error(err.to_string()),
             None => Poll::Done,


### PR DESCRIPTION
This PR adds DebugNode as an option to the API.  Useful for both testing and dev purposes.

Pipeline code for node/window tests is still written by hand as the tests require a bit more control of markers.

Closes #156 

Windows CI seems to be fixed by the state directory changes in ``cfg(test)`` mode.  Closes #178

```rust
let mut pipeline = Pipeline::default().with_debug_node();

let stream = pipeline.
   .collection((0..100).collect::<Vec<u64>>(), |conf| {
       conf.set_arcon_time(ArconTime::Event);
       conf.set_timestamp_extractor(|x: &u64| *x);
   })
   .operator(OperatorBuilder {
       constructor: Arc::new(|_| Map::new(|x| x + 10)),
       conf: Default::default(),
   });
  
let pipeline: AssembledPipeline = stream.build();

pipeline.start();

std::thread::sleep(std::time::Duration::from_millis(500));
let debug_node = pipeline.get_debug_node::<u64>().unwrap();

debug_node.on_definition(|cd| {
    let sum: u64 = cd.data.iter().map(|elem| elem.data).sum();
    assert_eq!(sum, 145);
});
```