### PR TITLE
Single Kafka Consumer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,7 @@ jobs:
             experimental: false
           - build: Windows
             os: windows-latest
+            features: cmake-build,libz-static
             experimental: true
     steps:
       - name: checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "prost-types 0.7.0",
  "rand 0.6.5",
  "rayon",
+ "rdkafka",
  "serde",
  "serde_json",
  "slog",
@@ -933,6 +934,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1653,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +1919,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "plotters"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2156,15 @@ dependencies = [
  "lazy_static",
  "term 0.5.2",
  "unicode-width",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -2430,6 +2491,35 @@ dependencies = [
  "crossbeam-utils 0.8.4",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af78bc431a82ef178c4ad6db537eb9cc25715a8591d27acc30455ee7227a76f4"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.0.0+1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f24572851adfeb525fdc4a1d51185898e54fed4e8d8dba4fadb90c6b4f0422"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3032,6 +3122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3189,12 @@ checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
 dependencies = [
  "ctor",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 default = ["serde"]
 arcon_serde = ["serde_json", "bincode", "serde", "uuid/serde"]
 unsafe_flight = ["abomonation", "abomonation_derive", "arcon_macros/unsafe_flight"]
-#kafka = ["rdkafka", "futures", "serde_json", "serde"]
+kafka = ["rdkafka", "futures", "serde_json", "serde"]
 thread_pinning = ["kompact/thread_pinning"]
 socket = ["tokio-util", "futures", "serde_json", "serde"]
 quiet = ["slog"]
@@ -66,7 +66,7 @@ arrow = "4.0.0"
 datafusion = "4.0.0"
 
 # Optional
-#rdkafka = { version = "0.23", optional = true }
+rdkafka = { version = "0.26", optional = true }
 tokio = { version = "1.0", features = ["full"] } # TODO: figure out which are truly needed
 tokio-util = { version = "0.6", optional = true, features = ["full"] }
 futures = { version = "0.3", optional = true }

--- a/arcon_macros/src/lib.rs
+++ b/arcon_macros/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! The arcon_macros crate contains macros used by [arcon].
+//! The arcon_macros crate contains macros used by arcon.
 
 #![recursion_limit = "128"]
 extern crate proc_macro;

--- a/guide/examples/Cargo.toml
+++ b/guide/examples/Cargo.toml
@@ -11,7 +11,7 @@ arcon_serde = ["arcon/arcon_serde", "arcon_build/arcon_serde"]
 default = []
 
 [dependencies]
-arcon = { path = "../../"}
+arcon = { path = "../../" , features = ["kafka"]}
 prost = "0.7"
 serde = { version = "1.0.104", features = ["derive"] }
 abomonation = "0.7.3"

--- a/guide/examples/src/bin/kafka_source.rs
+++ b/guide/examples/src/bin/kafka_source.rs
@@ -1,0 +1,24 @@
+use arcon::prelude::*;
+
+fn main() {
+    let consumer_conf = KafkaConsumerConf::default()
+        .with_topics(&["test"])
+        .set("group.id", "test")
+        .set("bootstrap.servers", "127.0.0.1:9092")
+        .set("enable.auto.commit", "false");
+
+    let mut pipeline = Pipeline::default()
+        .kafka(consumer_conf, |conf| {
+            conf.set_arcon_time(ArconTime::Event);
+            conf.set_timestamp_extractor(|x: &u64| *x);
+        })
+        .operator(OperatorBuilder {
+            constructor: Arc::new(|_| Map::new(|x| x + 10)),
+            conf: Default::default(),
+        })
+        .to_console()
+        .build();
+
+    pipeline.start();
+    pipeline.await_termination();
+}

--- a/guide/examples/src/bin/kafka_source.rs
+++ b/guide/examples/src/bin/kafka_source.rs
@@ -8,7 +8,7 @@ fn main() {
         .set("enable.auto.commit", "false");
 
     let mut pipeline = Pipeline::default()
-        .kafka(consumer_conf, |conf| {
+        .kafka(consumer_conf, JsonSchema::new(), |conf| {
             conf.set_arcon_time(ArconTime::Event);
             conf.set_timestamp_extractor(|x: &u64| *x);
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub mod prelude {
                 window::{AppenderWindow, IncrementalWindow, WindowAssigner},
                 Operator, OperatorContext,
             },
-            source::Source,
+            source::{schema::ProtoSchema, Source},
             time::{ArconTime, Time},
         },
         Arcon, ArconState,
@@ -159,6 +159,8 @@ pub mod prelude {
 
     #[cfg(feature = "kafka")]
     pub use crate::stream::source::kafka::KafkaConsumerConf;
+    #[cfg(feature = "serde_json")]
+    pub use crate::stream::source::schema::JsonSchema;
     #[cfg(feature = "kafka")]
     pub use rdkafka::config::ClientConfig;
     //pub use crate::stream::operator::sink::kafka::KafkaSink;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,10 @@ pub mod prelude {
     };
 
     #[cfg(feature = "kafka")]
-    pub use crate::stream::operator::sink::kafka::KafkaSink;
+    pub use crate::stream::source::kafka::KafkaConsumerConf;
+    #[cfg(feature = "kafka")]
+    pub use rdkafka::config::ClientConfig;
+    //pub use crate::stream::operator::sink::kafka::KafkaSink;
 
     pub use arcon_error::{arcon_err, arcon_err_kind, ArconResult, OperatorResult};
 

--- a/src/pipeline/assembled.rs
+++ b/src/pipeline/assembled.rs
@@ -65,9 +65,9 @@ impl AssembledPipeline {
         self.start_flag = true;
     }
 
-    /// Fetch [DebugNode] component of the [Pipeline]
+    /// Fetch DebugNode component of the [Pipeline]
     ///
-    /// Returns `None` if the [Pipeline] was not configured with a [DebugNode].
+    /// Returns `None` if the [Pipeline] was not configured with a DebugNode.
     /// Note that it is up to the user to make sure `A` is of correct type.
     pub fn get_debug_node<A>(&self) -> Option<Arc<Component<DebugNode<A>>>>
     where

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -301,7 +301,7 @@ impl Pipeline {
     ///  .set("enable.auto.commit", "false");
     ///
     /// let stream: Stream<u64> = Pipeline::default()
-    ///  .kafka(consumer_conf, JsonScheam::new(), |conf| {
+    ///  .kafka(consumer_conf, JsonSchema::new(), |conf| {
     ///     conf.set_arcon_time(ArconTime::Event);
     ///     conf.set_timestamp_extractor(|x: &u64| *x);
     ///  });
@@ -323,7 +323,7 @@ impl Pipeline {
         self.source(builder)
     }
 
-    /// Enable [DebugNode] for the Pipeline
+    /// Enable DebugNode for the Pipeline
     ///
     ///
     /// The component can be accessed through [method](AssembledPipeline::get_debug_node).

--- a/src/stream/operator/sink/mod.rs
+++ b/src/stream/operator/sink/mod.rs
@@ -7,5 +7,5 @@ pub mod local_file;
 #[allow(dead_code)]
 pub mod socket;
 
-#[cfg(feature = "kafka")]
-pub mod kafka;
+//#[cfg(feature = "kafka")]
+//pub mod kafka;

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -3,9 +3,9 @@
 
 use crate::data::ArconType;
 
+#[cfg(feature = "kafka")]
+pub mod kafka;
 pub mod local_file;
-//#[cfg(feature = "kafka")]
-//pub mod kafka;
 //#[cfg(feature = "socket")]
 //pub mod socket;
 

--- a/src/stream/source/mod.rs
+++ b/src/stream/source/mod.rs
@@ -6,6 +6,8 @@ use crate::data::ArconType;
 #[cfg(feature = "kafka")]
 pub mod kafka;
 pub mod local_file;
+pub mod schema;
+
 //#[cfg(feature = "socket")]
 //pub mod socket;
 

--- a/src/stream/source/schema.rs
+++ b/src/stream/source/schema.rs
@@ -1,0 +1,77 @@
+use crate::data::ArconType;
+use arcon_state::backend::serialization::protobuf;
+
+pub trait SourceSchema: Send + Sync + Clone + 'static {
+    type Data: ArconType;
+
+    fn from_bytes(&self, bytes: &[u8]) -> Option<Self::Data>;
+}
+
+#[cfg(feature = "serde_json")]
+#[derive(Clone)]
+pub struct JsonSchema<IN>
+where
+    IN: ArconType + ::serde::de::DeserializeOwned,
+{
+    _marker: std::marker::PhantomData<IN>,
+}
+
+#[cfg(feature = "serde_json")]
+impl<IN> JsonSchema<IN>
+where
+    IN: ArconType + ::serde::de::DeserializeOwned,
+{
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "serde_json")]
+impl<IN> SourceSchema for JsonSchema<IN>
+where
+    IN: ArconType + ::serde::de::DeserializeOwned,
+{
+    type Data = IN;
+
+    fn from_bytes(&self, bytes: &[u8]) -> Option<Self::Data> {
+        match serde_json::from_str(std::str::from_utf8(&bytes).unwrap()) {
+            Ok(data) => Some(data),
+            Err(_) => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ProtoSchema<IN>
+where
+    IN: ArconType,
+{
+    _marker: std::marker::PhantomData<IN>,
+}
+
+impl<IN> ProtoSchema<IN>
+where
+    IN: ArconType,
+{
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<IN> SourceSchema for ProtoSchema<IN>
+where
+    IN: ArconType,
+{
+    type Data = IN;
+
+    fn from_bytes(&self, bytes: &[u8]) -> Option<Self::Data> {
+        match protobuf::deserialize(bytes) {
+            Ok(data) => Some(data),
+            Err(_) => None,
+        }
+    }
+}

--- a/src/stream/source/schema.rs
+++ b/src/stream/source/schema.rs
@@ -17,6 +17,16 @@ where
 }
 
 #[cfg(feature = "serde_json")]
+impl<IN> Default for JsonSchema<IN>
+where
+    IN: ArconType + ::serde::de::DeserializeOwned,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "serde_json")]
 impl<IN> JsonSchema<IN>
 where
     IN: ArconType + ::serde::de::DeserializeOwned,
@@ -49,6 +59,15 @@ where
     IN: ArconType,
 {
     _marker: std::marker::PhantomData<IN>,
+}
+
+impl<IN> Default for ProtoSchema<IN>
+where
+    IN: ArconType,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<IN> ProtoSchema<IN>


### PR DESCRIPTION
This PR adds initial Kafka (#73 ) support mainly for playing around with as there is no integration with snapshots/offsets etc...

Error handling can be improved after #191 is fixed. 

Down below is a working example where the pipeline consumes data from the topic ``test``.

NOTE:  There is just a single Source component.  Parallel support will have to be for another PR.

```rust
use arcon::prelude::*;

fn main() {
    let consumer_conf = KafkaConsumerConf::default()
        .with_topics(&["test"])
        .set("group.id", "test")
        .set("bootstrap.servers", "127.0.0.1:9092")
        .set("enable.auto.commit", "false");

    let mut pipeline = Pipeline::default()
        .kafka(consumer_conf, JsonSchema::new(), |conf| {
            conf.set_arcon_time(ArconTime::Event);
            conf.set_timestamp_extractor(|x: &u64| *x);
        })
        .operator(OperatorBuilder {
            constructor: Arc::new(|_| Map::new(|x| x + 10)),
            conf: Default::default(),
        })
        .to_console()
        .build();

    pipeline.start();
    pipeline.await_termination();
}
```