### PR TITLE
Operator methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ fn main() {
             conf.set_arcon_time(ArconTime::Event);
             conf.set_timestamp_extractor(|x: &u64| *x);
         })
-        .operator(OperatorBuilder {
-            constructor: Arc::new(|_| Filter::new(|x| *x > 50)),
-            conf: Default::default(),
-        })
+        .filter(|x| *x > 50)
         .to_console()
         .build();
 

--- a/src/dataflow/conf.rs
+++ b/src/dataflow/conf.rs
@@ -14,7 +14,10 @@ use std::{path::Path, sync::Arc};
 // custom-defined state but still need a backend defined for internal runtime state.
 cfg_if::cfg_if! {
     if #[cfg(feature = "rocksdb")]  {
+        #[cfg(not(test))]
         pub type DefaultBackend = arcon_state::Rocks;
+        #[cfg(test)]
+        pub type DefaultBackend = arcon_state::Sled;
     } else {
         pub type DefaultBackend = arcon_state::Sled;
     }

--- a/src/error/timer.rs
+++ b/src/error/timer.rs
@@ -5,13 +5,8 @@ use super::{ArconResult, Error};
 use snafu::Snafu;
 use std::fmt::Debug;
 
+/// TimerResult type utilised while scheduling timers
 pub type TimerResult<A> = ArconResult<std::result::Result<(), TimerExpiredError<A>>>;
-
-impl<A: Debug> From<Error> for TimerResult<A> {
-    fn from(error: Error) -> Self {
-        Err(error)
-    }
-}
 
 #[derive(Debug, Snafu)]
 #[snafu(display(
@@ -27,4 +22,10 @@ pub struct TimerExpiredError<A: Debug> {
     pub scheduled_time: u64,
     /// Timer Entry
     pub entry: A,
+}
+
+impl<A: Debug> From<Error> for TimerResult<A> {
+    fn from(error: Error) -> Self {
+        Err(error)
+    }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -264,7 +264,7 @@ impl Pipeline {
     /// Returns a [`Stream`] object that users may execute transformations on.
     ///
     /// Example
-    /// ```
+    /// ```no_run
     /// use arcon::prelude::*;
     /// let stream: Stream<u64> = Pipeline::default()
     ///     .collection((0..100).collect::<Vec<u64>>(), |conf| {
@@ -292,7 +292,7 @@ impl Pipeline {
     /// Returns a [`Stream`] object that users may execute transformations on.
     ///
     /// Example
-    /// ```
+    /// ```no_run
     /// use arcon::prelude::*;
     /// let consumer_conf = KafkaConsumerConf::default()
     ///  .with_topics(&["test"])


### PR DESCRIPTION
This PR adds ``map``, ``map_in_place``,  ``filter``, and ``flatmap`` to the ``Stream`` object.  These methods are stateless and use the default Operator configuration. If users need more control, they are then recommended to use the operator function directly..