### PR TITLE
Add ArconLogger and LoggerType conf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "slog-async",
+ "slog-term",
  "snafu",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ unsafe_flight = ["abomonation", "abomonation_derive", "arcon_macros/unsafe_fligh
 kafka = ["rdkafka", "futures", "serde_json", "serde"]
 thread_pinning = ["kompact/thread_pinning"]
 socket = ["tokio-util", "futures", "serde_json", "serde"]
-quiet = ["slog"]
 metrics = []
 
 # state features
@@ -51,6 +50,11 @@ num_cpus = "1.0"
 hierarchical_hash_wheel_timer = "1.0"
 hocon = {version = "0.3", default-features = false, features = ["serde-support"]}
 snafu = "0.6"
+
+# Logging
+slog = "2"
+slog-async = "2"
+slog-term = "2"
 
 # Hashing
 fxhash = "0.2.1"
@@ -73,7 +77,6 @@ futures = { version = "0.3", optional = true }
 serde_json = { version = "1.0.44", optional = true }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
-slog = { version = "2.2", features = ["release_max_level_off"], optional = true }
 rayon = { version = "1.3.0", optional = true }
 abomonation = { version = "0.7.3", optional = true }
 abomonation_derive = { version = "0.5.0", optional = true }

--- a/arcon_shell/Cargo.toml
+++ b/arcon_shell/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Max Meldrum <mmeldrum@kth.se>"]
 edition = "2018"
 
 [dependencies]
-arcon = { path = "../", features = ["quiet"] } 
+arcon = { path = "../" }
 clap = "2.33"
 rustyline = "7.1.0"
 prettytable-rs = "0.8"

--- a/src/conf/logger.rs
+++ b/src/conf/logger.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2021, KTH Royal Institute of Technology.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use serde::Deserialize;
+use slog::{o, Drain, Fuse, Logger};
+use slog_async::Async;
+use std::{fs::OpenOptions, sync::Arc};
+
+/// Alias for logger in Arcon
+pub type ArconLogger = Logger<std::sync::Arc<Fuse<Async>>>;
+
+pub const ARCON_LOG_NAME: &str = "arcon.log";
+pub const KOMPACT_LOG_NAME: &str = "kompact.log";
+
+/// Defines a logger type
+#[derive(Deserialize, Clone, Debug)]
+pub enum LoggerType {
+    /// Logs output directly to the terminal
+    Terminal,
+    /// Logs output to file
+    File,
+}
+
+impl Default for LoggerType {
+    fn default() -> Self {
+        LoggerType::Terminal
+    }
+}
+pub fn term_logger() -> ArconLogger {
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).chan_size(1024).build().fuse();
+
+    slog::Logger::root_typed(
+        Arc::new(drain),
+        o!(
+        "location" => slog::PushFnValue(|r: &slog::Record<'_>, ser: slog::PushFnValueSerializer<'_>| {
+            ser.emit(format_args!("{}:{}", r.file(), r.line()))
+        })),
+    )
+}
+
+pub fn file_logger(log_path: &str) -> ArconLogger {
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(log_path)
+        .unwrap();
+
+    let decorator = slog_term::PlainDecorator::new(file);
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).chan_size(1024).build().fuse();
+
+    slog::Logger::root_typed(
+        Arc::new(drain),
+        o!(
+        "location" => slog::PushFnValue(|r: &slog::Record<'_>, ser: slog::PushFnValueSerializer<'_>| {
+            ser.emit(format_args!("{}:{}", r.file(), r.line()))
+        })),
+    )
+}

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -1,11 +1,14 @@
 // Copyright (c) 2020, KTH Royal Institute of Technology.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub mod logger;
+
 use hocon::HoconLoader;
 use kompact::{
     net::buffers::BufferConfig,
     prelude::{DeadletterBox, KompactConfig, NetworkConfig},
 };
+use logger::{file_logger, term_logger, ArconLogger, LoggerType};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
@@ -26,12 +29,15 @@ pub struct ArconConf {
     /// Either a `Local` or `Distributed` Execution Mode
     #[serde(default = "execution_mode_default")]
     pub execution_mode: ExecutionMode,
-    /// Base directory for live state backend data
-    #[serde(default = "state_dir_default")]
-    pub state_dir: PathBuf,
-    /// Base directory for checkpoints
-    #[serde(default = "checkpoint_dir_default")]
-    pub checkpoint_dir: PathBuf,
+    /// Base directory for the pipeline
+    #[serde(default = "base_dir_default")]
+    pub base_dir: PathBuf,
+    /// [LoggerType] for arcon related logging
+    #[serde(default)]
+    pub arcon_logger_type: LoggerType,
+    /// [LoggerType] for kompact related logging
+    #[serde(default)]
+    pub kompact_logger_type: LoggerType,
     /// Generation interval in milliseconds for Epochs
     #[serde(default = "epoch_interval_default")]
     pub epoch_interval: u64,
@@ -87,8 +93,9 @@ impl Default for ArconConf {
     fn default() -> Self {
         ArconConf {
             execution_mode: execution_mode_default(),
-            state_dir: state_dir_default(),
-            checkpoint_dir: checkpoint_dir_default(),
+            base_dir: base_dir_default(),
+            arcon_logger_type: Default::default(),
+            kompact_logger_type: Default::default(),
             watermark_interval: watermark_interval_default(),
             epoch_interval: epoch_interval_default(),
             max_key: max_key_default(),
@@ -111,6 +118,46 @@ impl Default for ArconConf {
 }
 
 impl ArconConf {
+    pub fn state_dir(&self) -> PathBuf {
+        let mut buf = self.base_dir.clone();
+        buf.push("live_states");
+        buf
+    }
+    pub fn checkpoints_dir(&self) -> PathBuf {
+        let mut buf = self.base_dir.clone();
+        buf.push("checkpoints");
+        buf
+    }
+
+    pub fn arcon_logger(&self) -> ArconLogger {
+        match self.arcon_logger_type {
+            LoggerType::File => {
+                let base_dir = self.base_dir.clone();
+                let path = format!(
+                    "{}/{}",
+                    base_dir.as_path().to_string_lossy(),
+                    logger::ARCON_LOG_NAME
+                );
+                file_logger(&path)
+            }
+            LoggerType::Terminal => term_logger(),
+        }
+    }
+
+    fn kompact_logger(&self) -> Option<kompact::KompactLogger> {
+        match self.kompact_logger_type {
+            LoggerType::File => {
+                let base_dir = self.base_dir.clone();
+                let path = format!(
+                    "{}/{}",
+                    base_dir.as_path().to_string_lossy(),
+                    logger::KOMPACT_LOG_NAME,
+                );
+                Some(file_logger(&path))
+            }
+            LoggerType::Terminal => None,
+        }
+    }
     pub(crate) fn ctrl_system_conf(&self) -> KompactConfig {
         let mut cfg = KompactConfig::default();
 
@@ -122,8 +169,13 @@ impl ArconConf {
         // inject checkpoint_dir into Kompact
         let component_cfg = format!(
             "{{ checkpoint_dir = {:?}, node_metrics_interval = {} }}",
-            self.checkpoint_dir, self.node_metrics_interval
+            self.checkpoints_dir(),
+            self.node_metrics_interval
         );
+
+        if let Some(kompact_logger) = self.kompact_logger() {
+            cfg.logger(kompact_logger);
+        }
 
         cfg.load_config_str(component_cfg);
 
@@ -147,9 +199,13 @@ impl ArconConf {
         // inject checkpoint_dir into Kompact
         let component_cfg = format!(
             "{{ checkpoint_dir = {:?}, node_metrics_interval = {} }}",
-            self.checkpoint_dir, self.node_metrics_interval
+            self.checkpoints_dir(),
+            self.node_metrics_interval
         );
 
+        if let Some(kompact_logger) = self.kompact_logger() {
+            cfg.logger(kompact_logger);
+        }
         cfg.load_config_str(component_cfg);
         cfg.set_config_value(&kompact::config_keys::system::THREADS, self.kompact_threads);
         cfg.set_config_value(
@@ -196,25 +252,15 @@ fn execution_mode_default() -> ExecutionMode {
     ExecutionMode::Local
 }
 
-fn state_dir_default() -> PathBuf {
+fn base_dir_default() -> PathBuf {
     #[cfg(test)]
-    let mut res = tempfile::tempdir().unwrap().into_path();
+    let res = tempfile::tempdir().unwrap().into_path();
     #[cfg(not(test))]
-    let mut res = std::env::temp_dir();
+    let res = std::env::temp_dir();
 
-    res.push("arcon/live_states");
     res
 }
 
-fn checkpoint_dir_default() -> PathBuf {
-    #[cfg(test)]
-    let mut res = tempfile::tempdir().unwrap().into_path();
-    #[cfg(not(test))]
-    let mut res = std::env::temp_dir();
-
-    res.push("arcon/checkpoints");
-    res
-}
 fn epoch_interval_default() -> u64 {
     // in milliseconds
     2000
@@ -298,14 +344,14 @@ mod tests {
         // Set up Config File
         let mut file = NamedTempFile::new().unwrap();
         let file_path = file.path().to_string_lossy().into_owned();
-        let config_str = r#"{checkpoint_dir: /dev/null, watermark_interval: 1000}"#;
+        let config_str = r#"{base_dir: /dev/null, watermark_interval: 1000}"#;
         file.write_all(config_str.as_bytes()).unwrap();
 
         // Load conf
         let conf: ArconConf = ArconConf::from_file(&file_path);
 
         // Check custom values
-        assert_eq!(conf.checkpoint_dir, PathBuf::from("/dev/null"));
+        assert_eq!(conf.base_dir, PathBuf::from("/dev/null"));
         assert_eq!(conf.watermark_interval, 1000);
         // Check defaults
         assert_eq!(conf.node_metrics_interval, node_metrics_interval_default());

--- a/src/dataflow/stream.rs
+++ b/src/dataflow/stream.rs
@@ -45,7 +45,7 @@ impl<IN: ArconType> Stream<IN> {
         OP: Operator<IN = IN> + 'static,
     {
         // Set up directory for the operator and create Backend
-        let mut state_dir = self.ctx.pipeline.arcon_conf().state_dir.clone();
+        let mut state_dir = self.ctx.pipeline.arcon_conf().state_dir();
         let state_id = builder.state_id();
         state_dir.push(state_id.clone());
         let backend = builder.create_backend(state_dir);
@@ -60,6 +60,7 @@ impl<IN: ArconType> Stream<IN> {
             self.ctx.pipeline.data_system.clone(),
             builder,
             backend,
+            self.ctx.pipeline.arcon_logger.clone(),
         );
 
         let prev_dfg_node = self.ctx.dfg.get_mut(&self.prev_dfg_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub mod prelude {
     };
     */
     pub use crate::{
-        conf::ArconConf,
+        conf::{logger::LoggerType, ArconConf},
         data::{ArconElement, ArconNever, ArconType, StateID, VersionId},
         dataflow::conf::{
             OperatorBuilder, OperatorConf, ParallelismStrategy, SourceBuilder, SourceConf,

--- a/src/manager/source.rs
+++ b/src/manager/source.rs
@@ -3,6 +3,7 @@
 
 use super::epoch::EpochEvent;
 use crate::{
+    conf::logger::ArconLogger,
     data::StateID,
     stream::{node::source::SourceEvent, time::ArconTime},
 };
@@ -47,6 +48,8 @@ pub(crate) struct SourceManager<B: Backend> {
     _backend: Arc<B>,
     /// Reference to the EpochManager
     epoch_manager: ActorRefStrong<EpochEvent>,
+
+    logger: ArconLogger,
 }
 
 impl<B: Backend> SourceManager<B> {
@@ -56,6 +59,7 @@ impl<B: Backend> SourceManager<B> {
         watermark_interval: u64,
         epoch_manager: ActorRefStrong<EpochEvent>,
         backend: Arc<B>,
+        logger: ArconLogger,
     ) -> Self {
         Self {
             ctx: ComponentContext::uninitialised(),
@@ -68,6 +72,7 @@ impl<B: Backend> SourceManager<B> {
             source_refs: Vec::new(),
             _backend: backend,
             epoch_manager,
+            logger,
         }
     }
 
@@ -98,10 +103,7 @@ impl<B: Backend> SourceManager<B> {
 
 impl<B: Backend> ComponentLifecycle for SourceManager<B> {
     fn on_start(&mut self) -> Handled {
-        info!(
-            self.ctx.log(),
-            "Started SourceManager for {}", self.state_id,
-        );
+        info!(self.logger, "Started SourceManager for {}", self.state_id,);
         Handled::Ok
     }
     fn on_stop(&mut self) -> Handled {

--- a/src/stream/node/source.rs
+++ b/src/stream/node/source.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::{
+    conf::logger::ArconLogger,
     data::{ArconElement, ArconEvent, Epoch, Watermark},
     manager::source::{SourceManagerEvent, SourceManagerPort},
     prelude::SourceConf,
@@ -45,6 +46,7 @@ where
     channel_strategy: RefCell<ChannelStrategy<S::Item>>,
     conf: SourceConf<S::Item>,
     source: S,
+    logger: ArconLogger,
 }
 
 impl<S> SourceNode<S>
@@ -55,6 +57,7 @@ where
         source: S,
         conf: SourceConf<S::Item>,
         channel_strategy: ChannelStrategy<S::Item>,
+        logger: ArconLogger,
     ) -> Self {
         Self {
             ctx: ComponentContext::uninitialised(),
@@ -66,6 +69,7 @@ where
             watermark: 0,
             conf,
             source,
+            logger,
         }
     }
     pub fn process(&mut self) {
@@ -97,7 +101,7 @@ where
                     break;
                 }
                 Poll::Error(err) => {
-                    error!(self.ctx.log(), "{}", err);
+                    error!(self.logger, "{}", err);
                     counter += 1;
                 }
                 Poll::Done => {

--- a/src/stream/operator/sink/local_file.rs
+++ b/src/stream/operator/sink/local_file.rs
@@ -77,50 +77,30 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        data::{ArconMessage, NodeID},
-        stream::{
-            channel::strategy::ChannelStrategy,
-            node::{Node, NodeState},
-        },
-    };
-    use kompact::prelude::ActorRefFactory;
-    use std::{
-        io::{BufRead, BufReader},
-        sync::Arc,
-    };
+    use crate::prelude::*;
+    use std::io::{BufRead, BufReader};
     use tempfile::NamedTempFile;
 
     #[test]
     fn local_file_sink_test() {
-        let system = KompactConfig::default().build().expect("KompactSystem");
-
         let file = NamedTempFile::new().unwrap();
         let file_path = file.path().to_string_lossy().into_owned();
 
-        let node_id = NodeID::new(1);
-        let backend = Arc::new(crate::test_utils::temp_backend());
-        let sink_comp = system.create(move || {
-            Node::new(
-                String::from("sink_comp"),
-                ChannelStrategy::Mute,
-                LocalFileSink::new(&file_path),
-                NodeState::new(NodeID::new(0), vec![node_id], backend.clone()),
-                backend,
-            )
-        });
-        system.start(&sink_comp);
-        let input_one = ArconMessage::element(6i32, None, node_id);
-        let input_two = ArconMessage::element(2i32, None, node_id);
-        let input_three = ArconMessage::element(15i32, None, node_id);
-        let input_four = ArconMessage::element(30i32, None, node_id);
+        let mut pipeline = Pipeline::default()
+            .with_debug_node()
+            .collection(vec![6i32, 2i32, 15i32, 30i32], |conf| {
+                conf.set_arcon_time(ArconTime::Process);
+            })
+            .operator(OperatorBuilder {
+                constructor: Arc::new(move |_| LocalFileSink::new(&file_path)),
+                conf: OperatorConf {
+                    parallelism_strategy: ParallelismStrategy::Static(1),
+                    ..Default::default()
+                },
+            })
+            .build();
 
-        let target_ref: ActorRefStrong<ArconMessage<i32>> =
-            sink_comp.actor_ref().hold().expect("Failed to fetch");
-        target_ref.tell(input_one);
-        target_ref.tell(input_two);
-        target_ref.tell(input_three);
-        target_ref.tell(input_four);
+        pipeline.start();
 
         std::thread::sleep(std::time::Duration::from_secs(1));
 
@@ -133,6 +113,5 @@ mod tests {
 
         let expected: Vec<i32> = vec![6, 2, 15, 30];
         assert_eq!(result, expected);
-        let _ = system.shutdown();
     }
 }

--- a/src/stream/operator/window/assigner.rs
+++ b/src/stream/operator/window/assigner.rs
@@ -352,6 +352,7 @@ mod tests {
             epoch_manager_ref,
             in_channels.clone(),
             backend.clone(),
+            pipeline.arcon_logger.clone(),
         );
 
         let node_manager_comp = pipeline.ctrl_system().create(|| nm);
@@ -383,6 +384,7 @@ mod tests {
             window_assigner,
             NodeState::new(NodeID::new(0), in_channels, backend.clone()),
             backend,
+            pipeline.arcon_logger.clone(),
         );
 
         let window_comp = pipeline.data_system().create(|| node);


### PR DESCRIPTION
this PR adds a custom logger for Arcon and makes it possible to configure the log type (terminal/file) through ``ArconConf``

By default the logger for both Arcon and Kompact is set to output logs to the terminal. If both have been configured with ``LoggerType::File``, the former will log to ``arcon.log`` and the latter ``kompact.log`` in the configured base directory of the pipeline.

Closes #194 