### PR TITLE
fix: state metrics #280

### DIFF
--- a/arcon_state/src/backend/sled/map_ops.rs
+++ b/arcon_state/src/backend/sled/map_ops.rs
@@ -61,7 +61,7 @@ impl MapOps for Sled {
         let key = handle.serialize_metakeys_and_key(key)?;
         let serialized = protobuf::serialize(value)?;
         #[cfg(feature = "metrics")]
-        record_bytes_read(handle.name(), serialized.len() as u64, self.name.as_str());
+        record_bytes_written(handle.name(), serialized.len() as u64, self.name.as_str());
         self.put(&handle.id, &key, &serialized)?;
 
         Ok(())
@@ -77,7 +77,7 @@ impl MapOps for Sled {
 
         let serialized = protobuf::serialize(&value)?;
         #[cfg(feature = "metrics")]
-        record_bytes_read(handle.name(), serialized.len() as u64, self.name.as_str());
+        record_bytes_written(handle.name(), serialized.len() as u64, self.name.as_str());
         let old = match self.put(&handle.id, &key, &serialized)? {
             Some(x) => Some(protobuf::deserialize(&x)?),
             None => None,
@@ -98,7 +98,7 @@ impl MapOps for Sled {
             let key = handle.serialize_metakeys_and_key(&user_key)?;
             let serialized = protobuf::serialize(&value)?;
             #[cfg(feature = "metrics")]
-            record_bytes_read(handle.name(), serialized.len() as u64, self.name.as_str());
+            record_bytes_written(handle.name(), serialized.len() as u64, self.name.as_str());
             batch.insert(key, serialized);
         }
 
@@ -117,7 +117,7 @@ impl MapOps for Sled {
             let key = handle.serialize_metakeys_and_key(user_key)?;
             let serialized = protobuf::serialize(value)?;
             #[cfg(feature = "metrics")]
-            record_bytes_read(handle.name(), serialized.len() as u64, self.name.as_str());
+            record_bytes_written(handle.name(), serialized.len() as u64, self.name.as_str());
             batch.insert(key, serialized);
         }
 


### PR DESCRIPTION
Closes #280  

Fixes some calls. We should however later have the recording more unfied instead of having them in each ops method like now. Perhaps in the ``serialize/deserialize`` functions themselves.