### PR TITLE
chore: add native murmur3 hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcon_util"
+version = "0.1.0"
+dependencies = [
+ "mur3",
+]
+
+[[package]]
 name = "arr_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +1998,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "mur3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
 name = "nibble_vec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ A runtime for writing streaming applications
 members = [
     "arcon_build",
     "arcon_tests",
-    "arcon_examples"
+    "arcon_examples",
+    "arcon_util"
 ]
 
 exclude = [

--- a/arcon_util/Cargo.toml
+++ b/arcon_util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "arcon_util"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+default = []
+hasher = ["mur3"]
+
+[dependencies]
+mur3 = { version = "0.1.0", optional = true }

--- a/arcon_util/src/lib.rs
+++ b/arcon_util/src/lib.rs
@@ -1,0 +1,12 @@
+/// Alias type for Hasher used to shard data in Arcon
+///
+/// Arcon uses MurmurHash3
+#[cfg(feature = "hasher")]
+pub type KeyHasher = mur3::Hasher32;
+
+/// Helper function to create [KeyHasher]
+#[cfg(feature = "hasher")]
+#[inline]
+pub fn key_hasher() -> KeyHasher {
+    KeyHasher::with_seed(0)
+}


### PR DESCRIPTION
We will need a hasher for #286 

Murmur seems like a standard for sharding in data processing systems. 

1. Consistent output across machines/architectures 
2. Decent performance 
3. Good distribution properties.