### PR TITLE
Adding key_by() function to Stream<T>

### DIFF
--- a/arcon/arcon_state/src/backend/sled/mod.rs
+++ b/arcon/arcon_state/src/backend/sled/mod.rs
@@ -280,6 +280,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     pub struct TestDb {
         sled: Arc<Sled>,
     }

--- a/arcon/src/application/assembled.rs
+++ b/arcon/src/application/assembled.rs
@@ -9,9 +9,7 @@ use crate::{
     },
     stream::node::{debug::DebugNode, source::SourceEvent},
 };
-use kompact::prelude::{
-    ActorPath, ActorRefFactory, ActorRefStrong, Component, KompactSystem, NamedPath,
-};
+use kompact::prelude::{ActorRefFactory, ActorRefStrong, Component, KompactSystem};
 use std::sync::Arc;
 
 /// An [`Application`] that has been fully assembled
@@ -139,25 +137,6 @@ impl AssembledApplication {
 
     pub(crate) fn snapshot_manager(&self) -> &Arc<Component<SnapshotManager>> {
         &self.snapshot_manager
-    }
-
-    // NOTE: this function can be used while we are building up the dataflow.
-    // Basically, we want to send information about this Arcon Process (conf.arcon_pid)
-    // to the ControlPlane.
-    pub(crate) fn _register_app(&mut self) {
-        let _source_manager: ActorPath = NamedPath::with_system(
-            self.ctrl_system().system_path(),
-            vec!["source_manager".into()],
-        )
-        .into();
-        /*
-        let _app = AppRegistration {
-            name: self.app.conf.app_name.clone(),
-            arcon_pids: vec![self.app.conf.arcon_pid], // TODO: all pids..
-            sources: vec![source_manager.to_string()],
-            pid: self.app.conf.process_id,
-        };*/
-        // TODO: communicate with a component at the ControlPlane
     }
 
     /// Fetch DebugNode component of the [Application]

--- a/arcon/src/application/assembled.rs
+++ b/arcon/src/application/assembled.rs
@@ -1,23 +1,177 @@
 use super::Application;
 use crate::{
+    application::{conf::ApplicationConf, conf::ExecutionMode, ArconLogger},
     data::ArconType,
+    dataflow::constructor::{ErasedComponent, ErasedSourceManager},
+    manager::{
+        epoch::{EpochEvent, EpochManager},
+        snapshot::SnapshotManager,
+    },
     stream::node::{debug::DebugNode, source::SourceEvent},
 };
-use kompact::prelude::{ActorRefFactory, Component};
+use kompact::prelude::{
+    ActorPath, ActorRefFactory, ActorRefStrong, Component, KompactSystem, NamedPath,
+};
 use std::sync::Arc;
 
 /// An [`Application`] that has been fully assembled
+#[derive(Clone)]
 pub struct AssembledApplication {
-    app: Application,
+    pub(crate) app: Application,
     start_flag: bool,
+    pub(crate) runtime: Runtime,
+    // Type erased Arc<Component<DebugNode<A>>>
+    pub(crate) debug_node: Option<ErasedComponent>,
+    // Type erased Arc<dyn AbstractComponent<Message = ArconMessage<A>>>
+    pub(crate) abstract_debug_node: Option<ErasedComponent>,
+    /// SourceManager component for this application
+    pub(crate) source_manager: Option<ErasedSourceManager>,
+    /// EpochManager component for this application
+    pub(crate) epoch_manager: Option<Arc<Component<EpochManager>>>,
+    /// SnapshotManager component for this application
+    pub(crate) snapshot_manager: Arc<Component<SnapshotManager>>,
+}
+
+#[derive(Clone)]
+pub struct Runtime {
+    /// [`KompactSystem`] for Control Components
+    pub(crate) ctrl_system: KompactSystem,
+    /// [`KompactSystem`] for Data Processing Components
+    pub(crate) data_system: KompactSystem,
+}
+
+impl Runtime {
+    /// Helper function to set up internals of the application
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn new(arcon_conf: &ApplicationConf, _logger: &ArconLogger) -> Runtime {
+        let data_system = arcon_conf
+            .data_system_conf()
+            .build()
+            .expect("KompactSystem");
+        let ctrl_system = arcon_conf
+            .ctrl_system_conf()
+            .build()
+            .expect("KompactSystem");
+
+        Runtime {
+            ctrl_system,
+            data_system,
+        }
+    }
 }
 
 impl AssembledApplication {
-    pub(crate) fn new(app: Application) -> Self {
+    pub(crate) fn new(app: Application, runtime: Runtime) -> Self {
+        let timeout = std::time::Duration::from_millis(500);
+
+        let snapshot_manager = runtime.ctrl_system.create(SnapshotManager::new);
+
+        let epoch_manager = match app.conf.execution_mode {
+            ExecutionMode::Local => {
+                let snapshot_manager_ref = snapshot_manager.actor_ref().hold().expect("fail");
+                let epoch_manager = runtime.ctrl_system.create(|| {
+                    EpochManager::new(
+                        app.conf.epoch_interval,
+                        snapshot_manager_ref,
+                        app.arcon_logger.clone(),
+                    )
+                });
+                runtime
+                    .ctrl_system
+                    .start_notify(&epoch_manager)
+                    .wait_timeout(timeout)
+                    .expect("EpochManager comp never started!");
+
+                Some(epoch_manager)
+            }
+            ExecutionMode::Distributed(_) => None,
+        };
+
+        runtime
+            .ctrl_system
+            .start_notify(&snapshot_manager)
+            .wait_timeout(timeout)
+            .expect("SnapshotManager comp never started!");
         Self {
             app,
             start_flag: false,
+            runtime,
+            debug_node: None,
+            abstract_debug_node: None,
+            source_manager: None,
+            snapshot_manager,
+            epoch_manager,
         }
+    }
+
+    /// Helper function to quickly set up a DefaultApplication (no Nodes/Pipelinedefined)
+    #[allow(dead_code)]
+    pub(crate) fn default() -> Self {
+        let app = Application::default();
+        let runtime = Runtime::new(&app.conf, &app.arcon_logger);
+        AssembledApplication::new(app, runtime)
+    }
+
+    pub(crate) fn set_source_manager(&mut self, source_manager: ErasedSourceManager) {
+        self.source_manager = Some(source_manager);
+    }
+
+    pub(crate) fn epoch_manager(&self) -> ActorRefStrong<EpochEvent> {
+        if let Some(epoch_manager) = &self.epoch_manager {
+            epoch_manager
+                .actor_ref()
+                .hold()
+                .expect("Failed to fetch actor ref")
+        } else {
+            panic!(
+                "Only local reference supported for now. should really be an ActorPath later on"
+            );
+        }
+    }
+
+    pub(crate) fn data_system(&self) -> &KompactSystem {
+        &self.runtime.data_system
+    }
+
+    pub(crate) fn ctrl_system(&self) -> &KompactSystem {
+        &self.runtime.ctrl_system
+    }
+
+    pub(crate) fn snapshot_manager(&self) -> &Arc<Component<SnapshotManager>> {
+        &self.snapshot_manager
+    }
+
+    // NOTE: this function can be used while we are building up the dataflow.
+    // Basically, we want to send information about this Arcon Process (conf.arcon_pid)
+    // to the ControlPlane.
+    pub(crate) fn _register_app(&mut self) {
+        let _source_manager: ActorPath = NamedPath::with_system(
+            self.ctrl_system().system_path(),
+            vec!["source_manager".into()],
+        )
+        .into();
+        /*
+        let _app = AppRegistration {
+            name: self.app.conf.app_name.clone(),
+            arcon_pids: vec![self.app.conf.arcon_pid], // TODO: all pids..
+            sources: vec![source_manager.to_string()],
+            pid: self.app.conf.process_id,
+        };*/
+        // TODO: communicate with a component at the ControlPlane
+    }
+
+    /// Fetch DebugNode component of the [Application]
+    ///
+    /// Returns `None` if the [Application] was not configured with a DebugNode.
+    /// Note that it is up to the user to make sure `A` is of correct type.
+    #[allow(dead_code)]
+    pub(crate) fn get_debug_node<A: ArconType>(&self) -> Option<Arc<Component<DebugNode<A>>>> {
+        self.debug_node.as_ref().map(|erased_comp| {
+            erased_comp
+                .clone()
+                .downcast::<Component<DebugNode<A>>>()
+                .unwrap()
+        })
     }
 }
 
@@ -34,7 +188,7 @@ impl AssembledApplication {
         );
 
         // Send start message to manager component
-        match &self.app.source_manager {
+        match &self.source_manager {
             Some(source_manager) => {
                 source_manager.actor_ref().tell(SourceEvent::Start);
             }
@@ -42,8 +196,8 @@ impl AssembledApplication {
         }
 
         // Start epoch manager to begin the injection of epochs into the application.
-        if let Some(epoch_manager) = &self.app.epoch_manager {
-            self.app
+        if let Some(epoch_manager) = &self.epoch_manager {
+            self.runtime
                 .ctrl_system
                 .start_notify(epoch_manager)
                 .wait_timeout(std::time::Duration::from_millis(500))
@@ -53,28 +207,17 @@ impl AssembledApplication {
         self.start_flag = true;
     }
 
-    /// Fetch DebugNode component of the [Application]
-    ///
-    /// Returns `None` if the [Application] was not configured with a DebugNode.
-    /// Note that it is up to the user to make sure `A` is of correct type.
-    pub fn get_debug_node<A>(&self) -> Option<Arc<Component<DebugNode<A>>>>
-    where
-        A: ArconType,
-    {
-        self.app.get_debug_node()
-    }
-
     /// Awaits termination from the application
     ///
     /// Note that this blocks the current thread
     pub fn await_termination(self) {
-        self.app.data_system.await_termination();
-        self.app.ctrl_system.await_termination();
+        self.runtime.data_system.await_termination();
+        self.runtime.ctrl_system.await_termination();
     }
 
     /// Shuts the application down and consumes the struct
     pub fn shutdown(self) {
-        let _ = self.app.data_system.shutdown();
-        let _ = self.app.ctrl_system.shutdown();
+        let _ = self.runtime.data_system.shutdown();
+        let _ = self.runtime.ctrl_system.shutdown();
     }
 }

--- a/arcon/src/application/conf/mod.rs
+++ b/arcon/src/application/conf/mod.rs
@@ -15,6 +15,8 @@ pub enum ExecutionMode {
     Local,
     Distributed(DistributedConf),
 }
+
+#[allow(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
 #[allow(dead_code)]
 pub struct DistributedConf {

--- a/arcon/src/application/conf/mod.rs
+++ b/arcon/src/application/conf/mod.rs
@@ -18,7 +18,6 @@ pub enum ExecutionMode {
 
 #[allow(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
-#[allow(dead_code)]
 pub struct DistributedConf {
     peers: Vec<String>, // ["192.168.1.1:2000",  "192.168.1.2:2000"]
 }

--- a/arcon/src/application/mod.rs
+++ b/arcon/src/application/mod.rs
@@ -279,6 +279,7 @@ impl Application {
     ///
     ///
     /// The component can be accessed through [method](AssembledApplication::get_debug_node).
+    #[must_use]
     pub fn with_debug_node(mut self) -> Self {
         self.debug_node_flag = true;
         self

--- a/arcon/src/application/mod.rs
+++ b/arcon/src/application/mod.rs
@@ -104,23 +104,11 @@ impl Application {
                 error!(arcon_logger, "metrics recorder has already been set");
             }
         }
-        /*
-        let control_plane = match &conf.control_plane_mode {
-            ControlPlaneMode::Embedded => {
-                let mut cp_conf = ControlPlaneConf::default();
-                let mut dir = conf.base_dir.clone();
-                dir.push("control_plane");
-                cp_conf.dir = dir;
-                ControlPlaneContainer::Embedded(ControlPlane::new(cp_conf))
-            }
-            ControlPlaneMode::Remote(addr) => ControlPlaneContainer::Remote(addr.clone()),
-        };
-        */
+
         Self {
             conf,
             dfg: DFG::default(),
             allocator,
-            //control_plane,
             debug_node_flag: false,
             arcon_logger,
         }

--- a/arcon/src/application/mod.rs
+++ b/arcon/src/application/mod.rs
@@ -313,36 +313,4 @@ impl Application {
     pub fn debug_node_enabled(&self) -> bool {
         self.debug_node_flag
     }
-
-    // internal helper to create a DebugNode from a Stream object
-    pub(crate) fn create_debug_node<A>(&mut self, node: DebugNode<A>)
-    where
-        A: ArconType,
-    {
-        assert!(
-            self.debug_node.is_none(),
-            "DebugNode has already been created!"
-        );
-        let component = self.ctrl_system.create(|| node);
-
-        self.ctrl_system
-            .start_notify(&component)
-            .wait_timeout(std::time::Duration::from_millis(500))
-            .expect("DebugNode comp never started!");
-
-        self.debug_node = Some(component.clone());
-        // define abstract version of the component as the building phase needs it to downcast properly..
-        let comp: Arc<dyn AbstractComponent<Message = ArconMessage<A>>> = component;
-        self.abstract_debug_node = Some(Arc::new(comp) as ErasedComponent);
-    }
-
-    // internal helper to help fetch DebugNode from an AssembledApplication
-    pub(crate) fn get_debug_node<A: ArconType>(&self) -> Option<Arc<Component<DebugNode<A>>>> {
-        self.debug_node.as_ref().map(|erased_comp| {
-            erased_comp
-                .clone()
-                .downcast::<Component<DebugNode<A>>>()
-                .unwrap()
-        })
-    }
 }

--- a/arcon/src/buffer/event/mod.rs
+++ b/arcon/src/buffer/event/mod.rs
@@ -112,6 +112,7 @@ impl<T> Drop for EventBuffer<T> {
 
 /// An EventBuffer writer
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct BufferWriter<T> {
     /// Reference to the underlying buffer
     buffer: Arc<EventBuffer<T>>,
@@ -301,6 +302,7 @@ impl<T> From<Vec<T>> for BufferReader<T> {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct PoolInfo {
     pub(crate) buffer_size: usize,

--- a/arcon/src/buffer/event/mod.rs
+++ b/arcon/src/buffer/event/mod.rs
@@ -214,6 +214,7 @@ impl<T> BufferReader<T> {
 
     /// Convert into Vec
     #[inline]
+    #[allow(clippy::uninit_vec)]
     pub fn to_vec(&self) -> Vec<T> {
         let mut dst = Vec::with_capacity(self.len);
         unsafe {

--- a/arcon/src/data/mod.rs
+++ b/arcon/src/data/mod.rs
@@ -43,9 +43,6 @@ where
     const RELIABLE_SER_ID: SerId;
     /// Current version of this ArconType
     const VERSION_ID: VersionId;
-
-    /// Return the key of this ArconType
-    fn get_key(&self) -> u64;
 }
 
 /// An Enum containing all possible stream events that may occur in an execution
@@ -279,80 +276,48 @@ impl ArconType for u32 {
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U32_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for u64 {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_U64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_U64_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for i32 {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I32_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for i64 {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_I64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_I64_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for ArconF32 {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F32_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F32_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for ArconF64 {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_F64_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_F64_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for bool {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_BOOLEAN_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_BOOLEAN_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
 }
 impl ArconType for String {
     #[cfg(feature = "unsafe_flight")]
     const UNSAFE_SER_ID: SerId = ser_id::UNSAFE_STRING_ID;
     const RELIABLE_SER_ID: SerId = ser_id::RELIABLE_STRING_ID;
     const VERSION_ID: VersionId = 1;
-
-    fn get_key(&self) -> u64 {
-        calc_hash(self)
-    }
-}
-
-fn calc_hash<T: std::hash::Hash>(t: &T) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    let mut s = DefaultHasher::new();
-    t.hash(&mut s);
-    s.finish()
 }
 
 /// Float wrapper for f32 in order to impl Hash [std::hash::Hash]
@@ -466,9 +431,6 @@ impl ArconType for ArconNever {
     const UNSAFE_SER_ID: SerId = ser_id::NEVER_ID;
     const RELIABLE_SER_ID: SerId = ser_id::NEVER_ID;
     const VERSION_ID: VersionId = 1;
-    fn get_key(&self) -> u64 {
-        0
-    }
 }
 impl fmt::Debug for ArconNever {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/arcon/src/data/partition.rs
+++ b/arcon/src/data/partition.rs
@@ -1,11 +1,10 @@
 use prost::*;
 use std::hash::Hash;
 
-type PartitionIndex = u64;
 /// Defines the total amount of keys in the key space
-const MAX_KEY: PartitionIndex = 65535;
+const MAX_KEY: u64 = 65535;
 
-pub fn create_shards(total: PartitionIndex) -> Vec<Shard> {
+pub fn create_shards(total: u64) -> Vec<Shard> {
     assert!(
         total < MAX_KEY,
         "Attempted to create more shards than allowed keys {}",
@@ -21,7 +20,7 @@ pub fn create_shards(total: PartitionIndex) -> Vec<Shard> {
         .collect()
 }
 
-pub fn shard_lookup<K>(data: &K, total_shards: PartitionIndex) -> PartitionIndex
+pub fn shard_lookup<K>(data: &K, total_shards: u64) -> u64
 where
     K: Hash + ?Sized,
 {
@@ -33,9 +32,9 @@ where
 
 #[inline]
 pub fn shard_lookup_with_key(
-    hashed_key: PartitionIndex,
-    total_shards: PartitionIndex,
-) -> PartitionIndex {
+    hashed_key: u64,
+    total_shards: u64,
+) -> u64 {
     let key = hashed_key % MAX_KEY;
     key * total_shards / MAX_KEY
 }
@@ -44,13 +43,13 @@ pub fn shard_lookup_with_key(
 #[derive(Debug)]
 pub struct Shard {
     /// Shard Identifier
-    id: PartitionIndex,
+    id: u64,
     /// Range of keys the shard is responsible for
     range: KeyRange,
 }
 
 impl Shard {
-    pub fn new(id: PartitionIndex, range: KeyRange) -> Self {
+    pub fn new(id: u64, range: KeyRange) -> Self {
         Self { id, range }
     }
 }
@@ -60,15 +59,15 @@ impl Shard {
 pub struct KeyRange {
     /// Start of the Key Range
     #[prost(uint64)]
-    pub start: PartitionIndex,
+    pub start: u64,
     /// End of the Key Range
     #[prost(uint64)]
-    pub end: PartitionIndex,
+    pub end: u64,
 }
 
 impl KeyRange {
     /// Creates a new KeyRange
-    pub fn new(start: PartitionIndex, end: PartitionIndex) -> KeyRange {
+    pub fn new(start: u64, end: u64) -> KeyRange {
         assert!(start < end, "start range has to be smaller than end range");
         KeyRange { start, end }
     }

--- a/arcon/src/data/partition.rs
+++ b/arcon/src/data/partition.rs
@@ -31,10 +31,7 @@ where
 }
 
 #[inline]
-pub fn shard_lookup_with_key(
-    hashed_key: u64,
-    total_shards: u64,
-) -> u64 {
+pub fn shard_lookup_with_key(hashed_key: u64, total_shards: u64) -> u64 {
     let key = hashed_key % MAX_KEY;
     key * total_shards / MAX_KEY
 }

--- a/arcon/src/dataflow/api.rs
+++ b/arcon/src/dataflow/api.rs
@@ -56,6 +56,7 @@ impl<OP: Operator, Backend: arcon_state::Backend> OperatorBuilder<OP, Backend> {
 type SourceIndex = usize;
 type TotalSources = usize;
 
+#[derive(Clone)]
 pub enum SourceBuilderType<S, B>
 where
     S: Source,

--- a/arcon/src/dataflow/conf.rs
+++ b/arcon/src/dataflow/conf.rs
@@ -122,5 +122,4 @@ impl<S: ArconType> Default for SourceConf<S> {
 #[derive(Clone, Copy)]
 pub struct WindowConf {
     pub assigner: Assigner,
-    pub kind: StreamKind,
 }

--- a/arcon/src/dataflow/conf.rs
+++ b/arcon/src/dataflow/conf.rs
@@ -114,7 +114,7 @@ impl<S: ArconType> Default for SourceConf<S> {
             extractor: None,
             time: Default::default(),
             batch_size: 1024,
-            name: format!("source_{}", uuid::Uuid::new_v4().to_string()),
+            name: format!("source_{}", uuid::Uuid::new_v4()),
         }
     }
 }

--- a/arcon/src/dataflow/constructor.rs
+++ b/arcon/src/dataflow/constructor.rs
@@ -1,12 +1,12 @@
 use crate::{
     application::conf::logger::ArconLogger,
-    application::Application,
+    application::AssembledApplication,
     buffer::event::PoolInfo,
-    data::{ArconMessage, ArconType, NodeID},
+    data::{flight_serde::FlightSerde, ArconMessage, ArconType, NodeID},
     dataflow::{
         api::{OperatorBuilder, SourceBuilderType},
-        conf::{ParallelismStrategy, SourceConf},
-        dfg::ChannelKind,
+        conf::SourceConf,
+        dfg::{ChannelKind, GlobalNodeId},
     },
     manager::{
         node::{NodeManager, NodeManagerPort},
@@ -18,6 +18,7 @@ use crate::{
             Channel,
         },
         node::{
+            debug::DebugNode,
             source::{SourceEvent, SourceNode},
             Node, NodeState,
         },
@@ -30,41 +31,31 @@ use arcon_state::Backend;
 use kompact::{
     component::AbstractComponent,
     prelude::{
-        biconnect_components, biconnect_ports, ActorRefFactory, ActorRefStrong, KompactSystem,
-        RequiredRef, *,
+        biconnect_components, biconnect_ports, ActorRefFactory, ActorRefStrong, RequiredRef, *,
     },
 };
-use std::{any::Any, convert::TryInto, path::PathBuf, sync::Arc};
+use std::any::type_name;
+use std::{any::Any, path::PathBuf, sync::Arc};
 
-pub type SourceManagerConstructor = Box<
-    dyn FnOnce(
-        Vec<Arc<dyn Any + Send + Sync>>,
-        ChannelKind,
-        &mut Application,
-    ) -> ErasedSourceManager,
->;
-pub type SourceConstructor = Box<
-    dyn FnOnce(
-        Vec<Arc<dyn Any + Send + Sync>>,
-        ChannelKind,
-        &mut KompactSystem,
-    ) -> Arc<dyn AbstractComponent<Message = SourceEvent>>,
->;
 pub type ErasedSourceManager = Arc<dyn AbstractComponent<Message = SourceEvent>>;
-pub type NodeManagerConstructor = Box<
-    dyn FnOnce(Vec<NodeID>, ErasedComponents, ChannelKind, &mut Application) -> ErasedComponents,
->;
 
 pub type ErasedComponent = Arc<dyn Any + Send + Sync>;
 pub type ErasedComponents = Vec<ErasedComponent>;
 
 fn channel_strategy<OUT: ArconType>(
     mut components: ErasedComponents,
+    paths: Vec<ActorPath>,
     node_id: NodeID,
     pool_info: PoolInfo,
     max_key: u64,
     channel_kind: ChannelKind,
 ) -> ChannelStrategy<OUT> {
+    eprintln!(
+        "building channel strategy with {} components and {} paths",
+        components.len(),
+        paths.len()
+    );
+    eprintln!("Building ChannelStrategy {}", type_name::<OUT>());
     match channel_kind {
         ChannelKind::Forward => {
             assert_eq!(components.len(), 1, "Expected a single component target");
@@ -85,6 +76,9 @@ fn channel_strategy<OUT: ArconType>(
                 let channel = Channel::Local(actor_ref);
                 channels.push(channel);
             }
+            for path in paths {
+                channels.push(Channel::Remote(path, FlightSerde::Reliable));
+            }
             ChannelStrategy::Keyed(Keyed::new(max_key, channels, node_id, pool_info))
         }
         ChannelKind::Console => ChannelStrategy::Console,
@@ -93,88 +87,342 @@ fn channel_strategy<OUT: ArconType>(
     }
 }
 
-pub(crate) fn source_manager_constructor<S: Source + 'static, B: Backend>(
+pub trait NodeFactory {
+    fn build_nodes(
+        &self,
+        node_ids: Vec<GlobalNodeId>,
+        in_channels: Vec<NodeID>,
+        components: ErasedComponents,
+        paths: Vec<ActorPath>,
+        application: &mut AssembledApplication,
+    ) -> Vec<(GlobalNodeId, ErasedComponent)>;
+
+    fn set_channel_kind(&mut self, channel_kind: ChannelKind);
+}
+
+pub trait SourceFactory {
+    fn build_source(
+        &self,
+        components: ErasedComponents,
+        paths: Vec<ActorPath>,
+        application: &mut AssembledApplication,
+    ) -> ErasedSourceManager;
+
+    fn set_channel_kind(&mut self, channel_kind: ChannelKind);
+}
+
+impl<OP: Operator + 'static, B: Backend> NodeFactory for NodeConstructor<OP, B> {
+    fn build_nodes(
+        &self,
+        node_ids: Vec<GlobalNodeId>,
+        in_channels: Vec<NodeID>,
+        mut components: ErasedComponents,
+        paths: Vec<ActorPath>,
+        application: &mut AssembledApplication,
+    ) -> Vec<(GlobalNodeId, ErasedComponent)> {
+        // Initialize state and manager
+        eprintln!("Initializing State Directory");
+        self.init_state_dir();
+        let node_manager = self.create_node_manager(application, &in_channels);
+
+        if components.is_empty() && paths.is_empty() && application.app.debug_node_enabled() {
+            components.push(self.create_debug_node(application));
+        }
+        for node_id in node_ids {
+            // Create the Nodes arguments
+            let node_descriptor = format!("{}_{}", self.descriptor, node_id.node_id.id);
+            let backend = self.create_backend(node_descriptor.clone());
+            let channel_strategy = channel_strategy(
+                components.clone(),
+                paths.clone(),
+                node_id.node_id,
+                application.app.get_pool_info().clone(),
+                application.app.conf.max_key,
+                self.channel_kind,
+            );
+
+            // Build the Node
+            let node = Node::new(
+                node_descriptor,
+                channel_strategy,
+                self.builder.operator.clone()(),
+                self.builder.state.clone()(backend.clone()),
+                NodeState::new(node_id.node_id, in_channels.clone(), backend.clone()),
+                backend.clone(),
+                self.logger.clone(),
+                application.epoch_manager().clone(),
+                #[cfg(all(feature = "hardware_counters", target_os = "linux", not(test)))]
+                builder.conf.perf_events.clone(),
+                node_id,
+            );
+            eprintln!("Creating the Node Component");
+            // Create the node and connect it to the NodeManager
+            self.create_node_component(application, node, &node_manager);
+        }
+        eprintln!("Starting the NodeManager");
+        // Start NodeManager
+        application
+            .ctrl_system()
+            .start_notify(&node_manager)
+            .wait_timeout(std::time::Duration::from_millis(2000))
+            .expect("Failed to start NodeManager");
+
+        // Fetch all created Nodes on this NodeManager and return them as Erased
+        // for the next stage..
+        node_manager.on_definition(|cd| {
+            cd.nodes
+                .iter()
+                .map(|(id, (comp, _))| (*id, Arc::new(comp.clone()) as ErasedComponent))
+                .collect()
+        })
+    }
+
+    fn set_channel_kind(&mut self, channel_kind: ChannelKind) {
+        self.channel_kind = channel_kind;
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct NodeConstructor<OP: Operator + 'static, B: Backend> {
+    descriptor: String,
+    state_dir: PathBuf,
+    logger: ArconLogger,
+    channel_kind: ChannelKind,
+    builder: Arc<OperatorBuilder<OP, B>>,
+    // node_manager: Option<Arc<Component<NodeManager<OP, B>>>>,
+}
+
+impl<OP: Operator + 'static, B: Backend> NodeConstructor<OP, B> {
+    pub fn new(
+        descriptor: String,
+        state_dir: PathBuf,
+        builder: Arc<OperatorBuilder<OP, B>>,
+        logger: ArconLogger,
+    ) -> NodeConstructor<OP, B> {
+        NodeConstructor {
+            descriptor,
+            state_dir,
+            logger,
+            channel_kind: ChannelKind::default(),
+            builder,
+            // node_manager: None,
+        }
+    }
+
+    fn create_node_component(
+        &self,
+        application: &mut AssembledApplication,
+        node: Node<OP, B>,
+        node_manager: &Arc<Component<NodeManager<OP, B>>>,
+    ) {
+        let node_id = node.node_id;
+        let node_comp = application.data_system().create(|| node);
+        let required_ref: RequiredRef<NodeManagerPort> = node_comp.required_ref();
+
+        biconnect_components::<NodeManagerPort, _, _>(node_manager, &node_comp).expect("fail");
+
+        let node_comp: Arc<dyn AbstractComponent<Message = ArconMessage<OP::IN>>> = node_comp;
+
+        application
+            .data_system()
+            .start_notify(&node_comp)
+            .wait_timeout(std::time::Duration::from_millis(5000))
+            .expect("Failed to start Node Component");
+
+        node_manager.on_definition(|cd| {
+            // Insert the created Node into the NodeManager
+            cd.nodes.insert(node_id, (node_comp.clone(), required_ref));
+        });
+        // node_comp
+    }
+
+    fn create_debug_node(&self, application: &mut AssembledApplication) -> ErasedComponent {
+        eprintln!("Building DebugNode {}", type_name::<OP::OUT>());
+        let debug_node = DebugNode::<OP::OUT>::new();
+        let debug_component = application.data_system().create(|| debug_node);
+        application
+            .data_system()
+            .start_notify(&debug_component)
+            .wait_timeout(std::time::Duration::from_millis(5000))
+            .expect("Failed to start Node Component");
+
+        application.debug_node = Some(debug_component.clone());
+        let debug_component: Arc<dyn AbstractComponent<Message = ArconMessage<OP::OUT>>> =
+            debug_component;
+        let erased = Arc::new(debug_component) as ErasedComponent;
+
+        application.abstract_debug_node = Some(erased.clone());
+        erased
+    }
+
+    fn create_backend(&self, node_descriptor: String) -> Arc<B> {
+        let mut node_dir = self.state_dir.clone();
+        node_dir.push(&node_descriptor);
+        self.builder
+            .create_backend(node_dir, node_descriptor.clone())
+    }
+
+    /// Initializes things like state directory and NodeManager
+    fn create_node_manager(
+        &self,
+        application: &mut AssembledApplication,
+        in_channels: &[NodeID],
+    ) -> Arc<Component<NodeManager<OP, B>>> {
+        // if self.node_manager.is_none() {
+        // Define the NodeManager
+        let manager = NodeManager::<OP, B>::new(
+            self.descriptor.clone(),
+            application.data_system().clone(),
+            in_channels.to_vec(),
+            self.logger.clone(),
+            self.builder.clone(),
+        );
+        // Create the actual NodeManager component
+        let manager_comp = application.ctrl_system().create(|| manager);
+
+        // Connect NodeManager to the SnapshotManager of the application
+        application.snapshot_manager().on_definition(|scd| {
+            manager_comp.on_definition(|cd| {
+                biconnect_ports(&mut scd.manager_port, &mut cd.snapshot_manager_port);
+            });
+        });
+        manager_comp
+        //    self.node_manager = Some(manager_comp);
+        // }
+    }
+
+    fn init_state_dir(&self) {
+        // Ensure there's a state_directory
+        std::fs::create_dir_all(&self.state_dir).unwrap();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SourceConstructor<S: Source + 'static, B: Backend> {
     descriptor: String,
     builder_type: SourceBuilderType<S, B>,
     backend: Arc<B>,
     watermark_interval: u64,
     time: ArconTime,
-) -> SourceManagerConstructor {
-    Box::new(
-        move |components: Vec<Arc<dyn std::any::Any + Send + Sync>>,
-              channel_kind: ChannelKind,
-              app: &mut Application| {
-            let epoch_manager_ref = app.epoch_manager();
+    channel_kind: ChannelKind,
+}
 
-            let manager = SourceManager::new(
-                descriptor,
-                time,
-                watermark_interval,
-                epoch_manager_ref,
-                backend.clone(),
-                app.arcon_logger.clone(),
-            );
-            let source_manager_comp = app.ctrl_system().create(|| manager);
+impl<S: Source + 'static, B: Backend> SourceConstructor<S, B> {
+    pub(crate) fn new(
+        descriptor: String,
+        builder_type: SourceBuilderType<S, B>,
+        backend: Arc<B>,
+        watermark_interval: u64,
+        time: ArconTime,
+    ) -> Self {
+        SourceConstructor {
+            descriptor,
+            builder_type,
+            backend,
+            watermark_interval,
+            time,
+            channel_kind: ChannelKind::default(),
+        }
+    }
 
-            match builder_type {
-                SourceBuilderType::Single(builder) => {
-                    let source_cons = builder.constructor;
-                    let source_conf = builder.conf;
-                    let source_index = 0;
-                    let source = source_cons(backend.clone());
+    // Source Manager needs to be (re-)inserted after calling this function
+    fn create_source_manager(
+        &self,
+        application: &mut AssembledApplication,
+    ) -> Arc<Component<SourceManager<B>>> {
+        let manager = SourceManager::new(
+            self.descriptor.clone(),
+            self.time,
+            self.watermark_interval,
+            application.epoch_manager(),
+            self.backend.clone(),
+            application.app.arcon_logger.clone(),
+        );
+        application.ctrl_system().create(|| manager)
+    }
+
+    fn start_source_manager(
+        &self,
+        source_manager: &Arc<Component<SourceManager<B>>>,
+        application: &mut AssembledApplication,
+    ) {
+        let source_ref: ActorRefStrong<SourceEvent> =
+            source_manager.actor_ref().hold().expect("fail");
+        // Set source reference at the EpochManager
+        if let Some(epoch_manager) = &application.epoch_manager {
+            epoch_manager.on_definition(|cd| {
+                cd.source_manager = Some(source_ref);
+            });
+        }
+
+        application
+            .ctrl_system()
+            .start_notify(source_manager)
+            .wait_timeout(std::time::Duration::from_millis(2000))
+            .expect("Failed to start SourceManager");
+    }
+}
+
+impl<S: Source + 'static, B: Backend> SourceFactory for SourceConstructor<S, B> {
+    fn build_source(
+        &self,
+        components: ErasedComponents,
+        paths: Vec<ActorPath>,
+        application: &mut AssembledApplication,
+    ) -> ErasedSourceManager {
+        let source_manager = self.create_source_manager(application);
+
+        match &self.builder_type {
+            SourceBuilderType::Single(builder) => {
+                let source_cons = builder.constructor.clone();
+                let source_conf = builder.conf.clone();
+                let source_index = 0;
+                let source = source_cons(self.backend.clone());
+                create_source_node(
+                    application,
+                    source_index,
+                    components,
+                    paths,
+                    self.channel_kind,
+                    source,
+                    source_conf,
+                    &source_manager,
+                );
+            }
+            SourceBuilderType::Parallel(builder) => {
+                let source_cons = builder.constructor.clone();
+                let parallelism = builder.parallelism;
+                for source_index in 0..builder.parallelism {
+                    let source_conf = builder.conf.clone();
+                    let source = source_cons(self.backend.clone(), source_index, parallelism); // todo
                     create_source_node(
-                        app,
+                        application,
                         source_index,
                         components.clone(),
-                        channel_kind,
+                        paths.clone(),
+                        self.channel_kind,
                         source,
                         source_conf,
-                        &source_manager_comp,
+                        &source_manager,
                     );
                 }
-                SourceBuilderType::Parallel(builder) => {
-                    let source_cons = builder.constructor;
-                    let parallelism = builder.parallelism;
-                    for source_index in 0..builder.parallelism {
-                        let source_conf = builder.conf.clone();
-                        let source = source_cons(backend.clone(), source_index, parallelism); // todo
-                        create_source_node(
-                            app,
-                            source_index,
-                            components.clone(),
-                            channel_kind,
-                            source,
-                            source_conf,
-                            &source_manager_comp,
-                        );
-                    }
-                }
             }
-            let source_ref: ActorRefStrong<SourceEvent> =
-                source_manager_comp.actor_ref().hold().expect("fail");
+        }
+        self.start_source_manager(&source_manager, application);
+        source_manager
+    }
 
-            // Set source reference at the EpochManager
-            if let Some(epoch_manager) = &app.epoch_manager {
-                epoch_manager.on_definition(|cd| {
-                    cd.source_manager = Some(source_ref);
-                });
-            }
-
-            app.ctrl_system()
-                .start_notify(&source_manager_comp)
-                .wait_timeout(std::time::Duration::from_millis(2000))
-                .expect("Failed to start SourceManager");
-
-            source_manager_comp
-        },
-    )
+    fn set_channel_kind(&mut self, channel_kind: ChannelKind) {
+        self.channel_kind = channel_kind;
+    }
 }
 
 // helper function to create source node..
 fn create_source_node<S, B>(
-    app: &mut Application,
+    app: &mut AssembledApplication,
     source_index: usize,
-    components: Vec<Arc<dyn std::any::Any + Send + Sync>>,
+    components: ErasedComponents,
+    paths: Vec<ActorPath>,
     channel_kind: ChannelKind,
     source: S,
     source_conf: SourceConf<S::Item>,
@@ -183,10 +431,11 @@ fn create_source_node<S, B>(
     S: Source,
     B: Backend,
 {
-    let pool_info = app.get_pool_info();
-    let max_key = app.conf.max_key;
+    let pool_info = app.app.get_pool_info();
+    let max_key = app.app.conf.max_key;
     let channel_strategy = channel_strategy(
         components.clone(),
+        paths,
         NodeID::new(source_index as u32),
         pool_info,
         max_key,
@@ -197,139 +446,20 @@ fn create_source_node<S, B>(
         source,
         source_conf,
         channel_strategy,
-        app.arcon_logger.clone(),
+        app.app.arcon_logger.clone(),
     );
     let source_node_comp = app.data_system().create(|| source_node);
 
-    app.data_system()
-        .start_notify(&source_node_comp)
-        .wait_timeout(std::time::Duration::from_millis(2000))
-        .expect("Failed to start Source Node");
-
     biconnect_components::<SourceManagerPort, _, _>(source_manager_comp, &source_node_comp)
         .expect("failed to biconnect components");
+
+    app.data_system().start(&source_node_comp);
+    //.wait_timeout(std::time::Duration::from_millis(5000))
+    //.expect("Failed to start Source Node");
 
     let source_node_comp_dyn: Arc<dyn AbstractComponent<Message = SourceEvent>> = source_node_comp;
 
     source_manager_comp.on_definition(|cd| {
         cd.add_source(source_node_comp_dyn);
     });
-}
-
-pub(crate) fn node_manager_constructor<OP: Operator + 'static, B: Backend>(
-    descriptor: String,
-    state_dir: PathBuf,
-    data_system: KompactSystem,
-    builder: Arc<OperatorBuilder<OP, B>>,
-    logger: ArconLogger,
-) -> NodeManagerConstructor {
-    Box::new(
-        move |in_channels: Vec<NodeID>,
-              components: ErasedComponents,
-              channel_kind: ChannelKind,
-              app: &mut Application| {
-            let epoch_manager_ref = app.epoch_manager();
-
-            // How many instances of this Operator we are initially creating
-            let instances = match builder.conf.parallelism_strategy {
-                ParallelismStrategy::Static(s) => s,
-                _ => panic!("Managed ParallelismStrategy not supported yet"),
-            };
-
-            let max_key = app.conf.max_key as usize;
-
-            // create base dir
-            std::fs::create_dir_all(&state_dir).unwrap();
-
-            #[cfg(all(feature = "hardware_counters", target_os = "linux", not(test)))]
-            let perf_events = builder.conf.perf_events.clone();
-            // Fetch the Operator constructor from the builder
-            let operator = builder.operator.clone();
-            // Fetch the Operator state constructor from the builder
-            let operator_state = builder.state.clone();
-
-            // Define the NodeManager
-            let manager = NodeManager::<OP, B>::new(
-                descriptor.clone(),
-                data_system,
-                in_channels.clone(),
-                logger.clone(),
-                builder.clone(),
-            );
-            // Create the actual NodeManager component
-            let manager_comp = app.ctrl_system().create(|| manager);
-
-            // Connect NodeManager to the SnapshotManager of the app
-            app.snapshot_manager.on_definition(|scd| {
-                manager_comp.on_definition(|cd| {
-                    biconnect_ports(&mut scd.manager_port, &mut cd.snapshot_manager_port);
-                });
-            });
-
-            // Fetch PoolInfo object that ChannelStrategies use to organise their buffers
-            let pool_info = app.get_pool_info();
-
-            // Create `instances` number of Nodes and add them into the NodeManager
-            for (curr_node_id, _) in (0..instances).enumerate() {
-                let node_descriptor = format!("{}_{}", descriptor, curr_node_id);
-                let node_id = NodeID::new(curr_node_id.try_into().unwrap());
-                let mut node_dir = state_dir.clone();
-                node_dir.push(&node_descriptor);
-                let backend = builder.create_backend(node_dir, node_descriptor.clone());
-
-                let node = Node::new(
-                    node_descriptor,
-                    channel_strategy(
-                        components.clone(),
-                        node_id,
-                        pool_info.clone(),
-                        max_key as u64,
-                        channel_kind,
-                    ),
-                    operator(),
-                    operator_state(backend.clone()),
-                    NodeState::new(node_id, in_channels.clone(), backend.clone()),
-                    backend.clone(),
-                    app.arcon_logger.clone(),
-                    epoch_manager_ref.clone(),
-                    #[cfg(all(feature = "hardware_counters", target_os = "linux", not(test)))]
-                    perf_events.clone(),
-                );
-
-                let node_comp = app.data_system().create(|| node);
-                let required_ref: RequiredRef<NodeManagerPort> = node_comp.required_ref();
-                biconnect_components::<NodeManagerPort, _, _>(&manager_comp, &node_comp)
-                    .expect("fail");
-
-                let node_comp: Arc<dyn AbstractComponent<Message = ArconMessage<OP::IN>>> =
-                    node_comp;
-
-                app.data_system()
-                    .start_notify(&node_comp)
-                    .wait_timeout(std::time::Duration::from_millis(2000))
-                    .expect("Failed to start Node Component");
-
-                manager_comp.on_definition(|cd| {
-                    // Insert the created Node into the NodeManager
-                    cd.nodes.insert(node_id, (node_comp, required_ref));
-                });
-            }
-            // Start NodeManager
-            app.ctrl_system()
-                .start_notify(&manager_comp)
-                .wait_timeout(std::time::Duration::from_millis(2000))
-                .expect("Failed to start NodeManager");
-
-            // Fetch all created Nodes on this NodeManager and return them as Erased
-            // for the next stage..
-            let nodes: ErasedComponents = manager_comp.on_definition(|cd| {
-                cd.nodes
-                    .values()
-                    .map(|(comp, _)| Arc::new(comp.clone()) as ErasedComponent)
-                    .collect()
-            });
-
-            nodes
-        },
-    )
 }

--- a/arcon/src/dataflow/constructor.rs
+++ b/arcon/src/dataflow/constructor.rs
@@ -209,7 +209,7 @@ impl<OP: Operator + 'static, B: Backend> NodeFactory for NodeConstructor<OP, B> 
                 self.logger.clone(),
                 application.epoch_manager().clone(),
                 #[cfg(all(feature = "hardware_counters", target_os = "linux", not(test)))]
-                builder.conf.perf_events.clone(),
+                self.builder.conf.perf_events.clone(),
                 node_id,
                 self.in_key_builder.clone(),
             );
@@ -501,9 +501,10 @@ fn create_source_node<S, B>(
     biconnect_components::<SourceManagerPort, _, _>(source_manager_comp, &source_node_comp)
         .expect("failed to biconnect components");
 
-    app.data_system().start(&source_node_comp);
-    //.wait_timeout(std::time::Duration::from_millis(5000))
-    //.expect("Failed to start Source Node");
+    app.data_system()
+        .start_notify(&source_node_comp)
+        .wait_timeout(std::time::Duration::from_millis(5000))
+        .expect("Failed to start Source Node");
 
     let source_node_comp_dyn: Arc<dyn AbstractComponent<Message = SourceEvent>> = source_node_comp;
 

--- a/arcon/src/dataflow/dfg.rs
+++ b/arcon/src/dataflow/dfg.rs
@@ -1,9 +1,33 @@
 use super::constructor::*;
+use crate::data::NodeID;
+
+use crate::prelude::Arc;
+
+pub type OperatorId = usize;
+
+/// Logical Name, can be derived from a Deployment.
+/// Resolveable to an `ActorPath` during runtime.
+#[derive(Debug, Clone, PartialEq, std::cmp::Eq, std::hash::Hash, Copy)]
+pub struct GlobalNodeId {
+    pub operator_id: OperatorId,
+    pub node_id: NodeID,
+}
+
+#[allow(dead_code)]
+impl GlobalNodeId {
+    // Helper function to make place-holder GlobalNodeId (used in testing etc.)
+    pub fn null() -> GlobalNodeId {
+        GlobalNodeId {
+            operator_id: 0,
+            node_id: NodeID::new(0),
+        }
+    }
+}
 
 /// A logical dataflow-graph.
 #[allow(dead_code)]
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DFG {
     /// The graph is represented as a Vec for maximum space-efficiency.
     /// This works since nodes are never deleted from the graph.
@@ -13,66 +37,107 @@ pub struct DFG {
 impl DFG {
     /// Inserts a [`DFGNode`] into the dataflow graph and returns a unique
     /// identifier of it.
-    pub fn insert(&mut self, node: DFGNode) -> DFGNodeID {
-        let id = DFGNodeID(self.graph.len());
+    pub fn insert(&mut self, node: DFGNode) -> OperatorId {
+        let id = self.graph.len();
         self.graph.push(node);
         id
     }
 
-    /// Returns a reference to the [`DFGNode`] associated to a [`DFGNodeID`].
+    /// Returns a reference to the [`DFGNode`] associated to a [`OperatorId`].
     #[allow(dead_code)]
-    pub fn get(&self, id: &DFGNodeID) -> &DFGNode {
-        self.graph.get(id.0).unwrap()
+    pub fn get(&self, id: &OperatorId) -> &DFGNode {
+        self.graph.get(*id).unwrap()
     }
 
-    /// Returns a mutable reference to the [`DFGNode`] associated to a [`DFGNodeID`].
+    /// Returns a mutable reference to the [`DFGNode`] associated to a [`OperatorId`].
     #[allow(dead_code)]
-    pub fn get_mut(&mut self, id: &DFGNodeID) -> &mut DFGNode {
-        self.graph.get_mut(id.0).unwrap()
+    pub fn get_mut(&mut self, id: &OperatorId) -> &mut DFGNode {
+        self.graph.get_mut(*id).unwrap()
     }
 }
 
-/// The ID of a [`DFGNode`] in the dataflow graph.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct DFGNodeID(pub usize);
+// /// The ID of a [`DFGNode`] in the dataflow graph.
+// #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+// pub struct OperatorId(pub usize);
 
 /// A logical node in the dataflow graph.
 #[allow(dead_code)]
+#[derive(Clone)]
 pub struct DFGNode {
-    pub(crate) kind: DFGNodeKind,
-    pub(crate) outgoing_channels: usize,
-    pub(crate) ingoing_channels: usize,
+    pub kind: DFGNodeKind,
+    operator_id: OperatorId,
+    paralellism: usize,
+    outgoing_channels: Vec<NodeID>,
     /// Ingoing edges to a node.
-    pub(crate) ingoing: Vec<DFGNodeID>,
-    pub(crate) channel_kind: ChannelKind,
+    ingoing: Vec<NodeID>,
+    channel_kind: ChannelKind,
 }
 
 impl DFGNode {
     pub fn new(
         kind: DFGNodeKind,
-        outgoing_channels: usize,
-        ingoing_channels: usize,
-        ingoing: Vec<DFGNodeID>,
+        operator_id: OperatorId,
+        paralellism: usize,
+        ingoing: Vec<NodeID>,
     ) -> Self {
         Self {
             kind,
-            outgoing_channels,
-            ingoing_channels,
+            operator_id,
+            paralellism,
+            outgoing_channels: Vec::new(),
             ingoing,
             channel_kind: Default::default(),
         }
     }
+
+    /// Returns a vector of NodeID's which this node will receive messages from
+    pub fn get_input_channels(&self) -> &Vec<NodeID> {
+        &self.ingoing
+    }
+
+    /// Returns a vector of NodeID's for this node
+    pub fn get_node_ids(&self) -> Vec<NodeID> {
+        (0..self.paralellism)
+            .map(|i| NodeID::new(i as u32))
+            .collect()
+    }
+
+    /// Sets the number of outgoing channels from this node
+    pub fn set_outgoing_channels(&mut self, outgoing_channels: Vec<NodeID>) {
+        self.outgoing_channels = outgoing_channels;
+    }
+
+    /// Configures the outgoing ChannelKind for this nodes Factory
+    #[allow(dead_code)]
+    pub fn set_channel_kind(&mut self, _channel_kind: ChannelKind) {
+        match &mut self.kind {
+            DFGNodeKind::Source(_source_factory) => {
+                todo!();
+                // mutability issue...
+                //source_factory.set_channel_kind(channel_kind);
+            }
+            DFGNodeKind::Node(_node_factory) => {
+                todo!();
+                // node_factory.set_channel_kind(channel_kind);
+            }
+        }
+    }
+
+    /// Returns the ChannelKind
+    #[allow(dead_code)]
+    pub fn get_channel_kind(&self) -> &ChannelKind {
+        &self.channel_kind
+    }
+
+    pub fn get_operator_id(&self) -> OperatorId {
+        self.operator_id
+    }
 }
 
+#[derive(Clone)]
 pub enum DFGNodeKind {
-    Source(ChannelKind, SourceManagerConstructor),
-    Node(NodeManagerConstructor),
-}
-
-#[allow(dead_code)]
-pub enum SourceKind {
-    Single(SourceConstructor),
-    Parallel,
+    Source(Arc<dyn SourceFactory>),
+    Node(Arc<dyn NodeFactory>),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -128,9 +193,9 @@ fn create_dfg() {
     //        |          |
     //        +-> node2 -+
 
-    assert_eq!(DFGNodeID(0), node0);
-    assert_eq!(DFGNodeID(1), node1);
-    assert_eq!(DFGNodeID(2), node2);
-    assert_eq!(DFGNodeID(3), node3);
+    assert_eq!(OperatorId(0), node0);
+    assert_eq!(OperatorId(1), node1);
+    assert_eq!(OperatorId(2), node2);
+    assert_eq!(OperatorId(3), node3);
 }
 */

--- a/arcon/src/dataflow/dfg.rs
+++ b/arcon/src/dataflow/dfg.rs
@@ -107,22 +107,6 @@ impl DFGNode {
         self.outgoing_channels = outgoing_channels;
     }
 
-    /// Configures the outgoing ChannelKind for this nodes Factory
-    #[allow(dead_code)]
-    pub fn set_channel_kind(&mut self, _channel_kind: ChannelKind) {
-        match &mut self.kind {
-            DFGNodeKind::Source(_source_factory) => {
-                todo!();
-                // mutability issue...
-                //source_factory.set_channel_kind(channel_kind);
-            }
-            DFGNodeKind::Node(_node_factory) => {
-                todo!();
-                // node_factory.set_channel_kind(channel_kind);
-            }
-        }
-    }
-
     /// Returns the ChannelKind
     #[allow(dead_code)]
     pub fn get_channel_kind(&self) -> &ChannelKind {
@@ -138,64 +122,31 @@ impl DFGNode {
 pub enum DFGNodeKind {
     Source(Arc<dyn SourceFactory>),
     Node(Arc<dyn NodeFactory>),
+    Placeholder,
 }
 
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 pub enum ChannelKind {
+    /// If Operator A with parallelism P (nodes a1, a2, ..., aP) sends messages
+    /// to Operator B with parallelism P (nodes b1, b2, ..., bP)
+    /// node a1 sends to b1, a2 sends to b2 etc.
     Forward,
+    /// If Operator A with parallelism P (nodes a1, a2, ..., aP) sends messages
+    /// to Operator B with parallelism P (nodes b1, b2, ..., bP)
+    /// all nodes executing A will broadcast each message to all nodes executing B.
     Broadcast,
+    /// Unimplemented
     RoundRobin,
+    /// Hashes elements according to a given key_extractor function and distributes the messages according to the hash.
     Keyed,
+    /// Logs outgoing elements to the console without sending anything
     Console,
+    /// Outgoing messages will be discarded
     Mute,
 }
 
 impl Default for ChannelKind {
     fn default() -> Self {
-        ChannelKind::Keyed
+        ChannelKind::Forward
     }
 }
-
-// TODO: Fix
-/*
-#[test]
-fn create_dfg() {
-    use DFGNodeKind::*;
-    let mut dfg = DFG::default();
-
-    let node0 = dfg.insert(DFGNode::new(
-        Node(Box::new(())),
-        OperatorConfig::default(),
-        vec![],
-    ));
-    let node1 = dfg.insert(DFGNode::new(
-        Node(Box::new(())),
-        OperatorConfig::default(),
-        vec![node0],
-    ));
-    let node2 = dfg.insert(DFGNode::new(
-        Node(Box::new(())),
-        OperatorConfig::default(),
-        vec![node0],
-    ));
-    let node3 = dfg.insert(DFGNode::new(
-        Node(Box::new(())),
-        OperatorConfig::default(),
-        vec![node1, node2],
-    ));
-
-    // Constructs the dataflow graph:
-    //
-    //        +-> node1 -+
-    //        |          |
-    // node0 -+          +-> node3
-    //        |          |
-    //        +-> node2 -+
-
-    assert_eq!(OperatorId(0), node0);
-    assert_eq!(OperatorId(1), node1);
-    assert_eq!(OperatorId(2), node2);
-    assert_eq!(OperatorId(3), node3);
-}
-*/

--- a/arcon/src/dataflow/dfg.rs
+++ b/arcon/src/dataflow/dfg.rs
@@ -56,10 +56,6 @@ impl DFG {
     }
 }
 
-// /// The ID of a [`DFGNode`] in the dataflow graph.
-// #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-// pub struct OperatorId(pub usize);
-
 /// A logical node in the dataflow graph.
 #[allow(dead_code)]
 #[derive(Clone)]

--- a/arcon/src/dataflow/stream.rs
+++ b/arcon/src/dataflow/stream.rs
@@ -85,6 +85,7 @@ impl<T: ArconType> Stream<T> {
     ///         conf.set_arcon_time(ArconTime::Process);
     ///     })
     ///     .key_by(|i: &u64| i);
+    /// ```
     pub fn key_by<F, KEY>(mut self, key_extractor: F) -> Stream<T>
     where
         KEY: Hash + 'static,
@@ -121,6 +122,7 @@ impl<T: ArconType> Stream<T> {
     ///         conf.set_arcon_time(ArconTime::Process);
     ///     })
     ///     .channel_kind(ChannelKind::Forward);
+    /// ```
     pub fn channel_kind(mut self, channel_kind: ChannelKind) -> Stream<T> {
         if let Some(ref mut node_factory) = self.last_node {
             let mut_node_factory = Arc::get_mut(node_factory).unwrap();

--- a/arcon/src/dataflow/stream.rs
+++ b/arcon/src/dataflow/stream.rs
@@ -86,6 +86,7 @@ impl<T: ArconType> Stream<T> {
     ///     })
     ///     .key_by(|i: &u64| i);
     /// ```
+    #[must_use]
     pub fn key_by<F, KEY>(mut self, key_extractor: F) -> Stream<T>
     where
         KEY: Hash + 'static,
@@ -123,6 +124,7 @@ impl<T: ArconType> Stream<T> {
     ///     })
     ///     .channel_kind(ChannelKind::Forward);
     /// ```
+    #[must_use]
     pub fn channel_kind(mut self, channel_kind: ChannelKind) -> Stream<T> {
         if let Some(ref mut node_factory) = self.last_node {
             let mut_node_factory = Arc::get_mut(node_factory).unwrap();
@@ -238,6 +240,7 @@ impl<T: ArconType> Stream<T> {
     ///     })
     ///     .map_in_place(|x| *x += 10);
     /// ```
+    #[must_use]
     pub fn map_in_place<F>(self, f: F) -> Stream<T>
     where
         F: Fn(&mut T) + ArconFnBounds,
@@ -262,6 +265,7 @@ impl<T: ArconType> Stream<T> {
     ///     })
     ///     .filter(|x| x < &50);
     /// ```
+    #[must_use]
     pub fn filter<F>(self, f: F) -> Stream<T>
     where
         F: Fn(&T) -> bool + ArconFnBounds,
@@ -303,6 +307,7 @@ impl<T: ArconType> Stream<T> {
     ///
     /// Note that if the Application has been configured with a debug node, it will take precedence.
     #[allow(clippy::wrong_self_convention)]
+    #[must_use]
     pub fn to_console(mut self) -> Stream<T> {
         self.ctx.console_output = true;
 

--- a/arcon/src/index/hash_table/table.rs
+++ b/arcon/src/index/hash_table/table.rs
@@ -1085,6 +1085,7 @@ impl<T> RawIterRange<T> {
 
 // We make raw iterators unconditionally Send and Sync, and let the PhantomData
 // in the actual iterator implementations determine the real Send/Sync bounds.
+#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T> Send for RawIterRange<T> {}
 unsafe impl<T> Sync for RawIterRange<T> {}
 

--- a/arcon/src/lib.rs
+++ b/arcon/src/lib.rs
@@ -144,6 +144,8 @@ pub mod prelude {
         dataflow::{
             api::{Assigner, OperatorBuilder, SourceBuilder},
             conf::{OperatorConf, ParallelismStrategy, SourceConf, StreamKind, WindowConf},
+            dfg::ChannelKind,
+            stream::KeyBuilder,
         },
         manager::snapshot::Snapshot,
         stream::{

--- a/arcon/src/manager/node.rs
+++ b/arcon/src/manager/node.rs
@@ -1,6 +1,7 @@
 use crate::{
     application::conf::logger::ArconLogger,
     data::{ArconMessage, Epoch, NodeID, StateID, Watermark},
+    dataflow::dfg::GlobalNodeId,
     error::*,
     index::EMPTY_STATE_ID,
     manager::snapshot::{Snapshot, SnapshotEvent, SnapshotManagerPort},
@@ -93,7 +94,7 @@ where
     /// Monotonically increasing Node ID index
     node_index: u32,
     /// Active Nodes on this NodeManager
-    pub(crate) nodes: FxHashMap<NodeID, AbstractNode<OP::IN>>,
+    pub(crate) nodes: FxHashMap<GlobalNodeId, AbstractNode<OP::IN>>,
     /// Internal manager state
     manager_state: NodeManagerState,
     latest_snapshot: Option<Snapshot>,
@@ -129,7 +130,7 @@ where
             max_node_parallelism: (num_cpus::get() * 2) as usize,
             node_index: 0,
             in_channels,
-            nodes: FxHashMap::default(),
+            nodes: FxHashMap::<GlobalNodeId, AbstractNode<OP::IN>>::default(),
             manager_state: NodeManagerState::new(),
             latest_snapshot: None,
             logger,

--- a/arcon/src/stream/channel/strategy/broadcast.rs
+++ b/arcon/src/stream/channel/strategy/broadcast.rs
@@ -159,7 +159,7 @@ where
 mod tests {
     use super::{Channel, *};
     use crate::{
-        application::Application,
+        application::assembled::AssembledApplication,
         data::{ArconElement, Watermark},
         stream::{
             channel::strategy::{send, tests::*, ChannelStrategy},
@@ -171,8 +171,8 @@ mod tests {
 
     #[test]
     fn broadcast_local_test() {
-        let mut app = Application::default();
-        let pool_info = app.get_pool_info();
+        let app = AssembledApplication::default();
+        let pool_info = app.app.get_pool_info();
         let system = app.data_system();
 
         let components: u32 = 8;

--- a/arcon/src/stream/channel/strategy/forward.rs
+++ b/arcon/src/stream/channel/strategy/forward.rs
@@ -99,7 +99,7 @@ where
 mod tests {
     use super::{Channel, *};
     use crate::{
-        application::Application,
+        application::assembled::AssembledApplication,
         data::{ArconElement, ArconEvent, Watermark},
         stream::{
             channel::strategy::{forward::Forward, send, tests::*, ChannelStrategy},
@@ -110,8 +110,8 @@ mod tests {
 
     #[test]
     fn forward_test() {
-        let mut app = Application::default();
-        let pool_info = app.get_pool_info();
+        let app = AssembledApplication::default();
+        let pool_info = app.app.get_pool_info();
         let system = app.data_system();
 
         let total_msgs = 10;

--- a/arcon/src/stream/channel/strategy/keyed.rs
+++ b/arcon/src/stream/channel/strategy/keyed.rs
@@ -148,7 +148,7 @@ where
 mod tests {
     use super::{Channel, *};
     use crate::{
-        application::Application,
+        application::assembled::AssembledApplication,
         data::{ArconElement, ArconEvent, NodeID, Watermark},
         stream::{
             channel::strategy::{send, tests::*, ChannelStrategy},
@@ -161,8 +161,8 @@ mod tests {
 
     #[test]
     fn keyby_test() {
-        let mut app = Application::default();
-        let pool_info = app.get_pool_info();
+        let app = AssembledApplication::default();
+        let pool_info = app.app.get_pool_info();
         let system = app.data_system();
 
         let parallelism: u32 = 8;

--- a/arcon/src/stream/node/debug.rs
+++ b/arcon/src/stream/node/debug.rs
@@ -2,6 +2,7 @@
 use crate::data::flight_serde::unsafe_remote::UnsafeSerde;
 use crate::data::{flight_serde::reliable_remote::ReliableSerde, *};
 use kompact::prelude::*;
+use std::collections::HashSet;
 
 /// A DebugNode is a debug version of [Node]
 ///
@@ -19,6 +20,8 @@ where
     pub watermarks: Vec<Watermark>,
     /// Buffer holding all received [Epoch]
     pub epochs: Vec<Epoch>,
+    /// Buffer holding all NodeID's the DebugNode has received messages from
+    pub senders: HashSet<NodeID>,
 }
 
 impl<IN> DebugNode<IN>
@@ -31,6 +34,7 @@ where
             data: Vec::new(),
             watermarks: Vec::new(),
             epochs: Vec::new(),
+            senders: HashSet::new(),
         }
     }
     #[inline]
@@ -82,6 +86,7 @@ where
     type Message = ArconMessage<IN>;
 
     fn receive_local(&mut self, msg: Self::Message) -> Handled {
+        self.senders.insert(msg.sender);
         self.handle_events(msg.events);
         Handled::Ok
     }
@@ -98,6 +103,7 @@ where
                 panic!("Unexpected deserialiser")
             }
         };
+        self.senders.insert(arcon_msg.sender);
         self.handle_events(arcon_msg.events);
         Handled::Ok
     }

--- a/arcon/src/stream/node/mod.rs
+++ b/arcon/src/stream/node/mod.rs
@@ -18,6 +18,7 @@ use crate::application::conf::logger::ArconLogger;
 use crate::data::flight_serde::unsafe_remote::UnsafeSerde;
 use crate::{
     data::{flight_serde::reliable_remote::ReliableSerde, RawArconMessage, *},
+    dataflow::dfg::GlobalNodeId,
     error::{ArconResult, *},
     index::{AppenderIndex, ArconState, EagerAppender, IndexOps},
     manager::epoch::EpochEvent,
@@ -131,6 +132,7 @@ where
     #[cfg(feature = "metrics")]
     /// Struct holding metrics information
     node_metrics: NodeMetrics,
+    pub node_id: GlobalNodeId,
 }
 
 impl<OP, B> Node<OP, B>
@@ -152,6 +154,7 @@ where
         #[cfg(all(feature = "hardware_counters", target_os = "linux"))]
         #[cfg(not(test))]
         perf_events: PerfEvents,
+        node_id: GlobalNodeId,
     ) -> Self {
         let timer_id = format!("_{}_timer", descriptor);
         let timer = crate::index::timer::Timer::new(timer_id, backend.clone());
@@ -195,6 +198,7 @@ where
             perf_events,
             #[cfg(feature = "metrics")]
             node_metrics: NodeMetrics::new(),
+            node_id,
         }
     }
 
@@ -619,8 +623,8 @@ mod tests {
         ) -> (ActorRef<ArconMessage<i32>>, Arc<Component<DebugNode<i32>>>) {
             // Returns a filter Node with input channels: sender1..sender3
             // And a debug sink receiving its results
-            let mut app = Application::default();
-            let pool_info = app.get_pool_info();
+            let app = AssembledApplication::default();
+            let pool_info = app.app.get_pool_info();
             let epoch_manager_ref = app.epoch_manager();
 
             let sink = app.data_system().create(DebugNode::<i32>::new);
@@ -650,9 +654,9 @@ mod tests {
 
             let nm = NodeManager::<OP, B>::new(
                 descriptor.clone(),
-                app.data_system.clone(),
+                app.data_system().clone(),
                 in_channels.clone(),
-                app.arcon_logger.clone(),
+                app.app.arcon_logger.clone(),
                 Arc::new(builder),
             );
             let node_manager_comp = app.ctrl_system().create(|| nm);
@@ -669,10 +673,11 @@ mod tests {
                 operator_state(backend.clone()),
                 NodeState::new(NodeID::new(0), in_channels, backend.clone()),
                 backend,
-                app.arcon_logger.clone(),
+                app.app.arcon_logger.clone(),
                 epoch_manager_ref,
                 #[cfg(not(test))]
                 perf_events,
+                GlobalNodeId::null(),
             );
 
             let filter_comp = app.data_system().create(|| node);
@@ -690,7 +695,8 @@ mod tests {
 
             node_manager_comp.on_definition(|cd| {
                 // Insert the created Node into the NodeManager
-                cd.nodes.insert(NodeID::new(0), (filter_comp, required_ref));
+                cd.nodes
+                    .insert(GlobalNodeId::null(), (filter_comp, required_ref));
             });
 
             (filter_ref, sink)

--- a/arcon/src/stream/operator/function/mod.rs
+++ b/arcon/src/stream/operator/function/mod.rs
@@ -44,7 +44,7 @@ mod tests {
     // helper to check common result between Map/MapInPlace
     fn check_map_result(mut app: AssembledApplication) {
         app.start();
-        wait(250);
+        wait(1000);
 
         let debug_node = app.get_debug_node::<i32>().unwrap();
 
@@ -66,7 +66,7 @@ mod tests {
 
         app.start();
 
-        wait(250);
+        wait(1000);
 
         let debug_node = app.get_debug_node::<i32>().unwrap();
 
@@ -87,7 +87,7 @@ mod tests {
 
         app.start();
 
-        wait(250);
+        wait(1000);
 
         let debug_node = app.get_debug_node::<i32>().unwrap();
 

--- a/arcon/src/stream/operator/sink/local_file.rs
+++ b/arcon/src/stream/operator/sink/local_file.rs
@@ -57,7 +57,7 @@ where
         _ctx: &mut OperatorContext<Self::TimerState, Self::OperatorState>,
     ) -> ArconResult<Self::ElementIterator> {
         if let Err(err) = writeln!(self.file.borrow_mut(), "{:?}", element.data) {
-            eprintln!("Error while writing to file sink {}", err.to_string());
+            eprintln!("Error while writing to file sink {}", err);
         }
         Ok(std::iter::empty::<ArconElement<Self::OUT>>())
     }

--- a/arcon/src/stream/operator/window/assigner.rs
+++ b/arcon/src/stream/operator/window/assigner.rs
@@ -124,13 +124,10 @@ where
 
         let ts = window_start + (window_ctx.index * self.window_slide) + self.window_length;
 
-        let current_key = ctx.current_key;
-        ctx.current_key = 0; // the "global" key
         let request = ctx.schedule_at(
             ts + self.late_arrival_time,
             WindowEvent::new(window_ctx.key, window_ctx.index, ts),
         )?;
-        ctx.current_key = current_key;
 
         if let Err(expired) = request {
             // For now just log the error..

--- a/arcon/src/stream/operator/window/assigner.rs
+++ b/arcon/src/stream/operator/window/assigner.rs
@@ -14,6 +14,7 @@ use crate::{
 use arcon_macros::ArconState;
 use arcon_state::Backend;
 use kompact::prelude::error;
+
 use prost::Message;
 use std::{marker::PhantomData, sync::Arc};
 
@@ -251,6 +252,7 @@ mod tests {
     use crate::{
         application::*,
         data::{ArconMessage, NodeID},
+        dataflow::dfg::GlobalNodeId,
         index::AppenderWindow,
         manager::node::{NodeManager, NodeManagerPort},
         prelude::OperatorBuilder,
@@ -276,8 +278,8 @@ mod tests {
         ActorRefStrong<ArconMessage<u64>>,
         Arc<Component<DebugNode<u64>>>,
     ) {
-        let mut app = Application::default();
-        let pool_info = app.get_pool_info();
+        let app = AssembledApplication::default();
+        let pool_info = app.app.get_pool_info();
         let epoch_manager_ref = app.epoch_manager();
 
         // Create a sink
@@ -329,9 +331,9 @@ mod tests {
 
         let nm = NodeManager::new(
             descriptor.clone(),
-            app.data_system.clone(),
+            app.data_system().clone(),
             in_channels.clone(),
-            app.arcon_logger.clone(),
+            app.app.arcon_logger.clone(),
             Arc::new(builder),
         );
 
@@ -353,11 +355,12 @@ mod tests {
             operator_state(backend.clone()),
             NodeState::new(NodeID::new(0), in_channels, backend.clone()),
             backend,
-            app.arcon_logger.clone(),
+            app.app.arcon_logger.clone(),
             epoch_manager_ref,
             #[cfg(feature = "hardware_counters")]
             #[cfg(not(test))]
             perf_events,
+            GlobalNodeId::null(),
         );
 
         let window_comp = app.data_system().create(|| node);
@@ -368,7 +371,7 @@ mod tests {
 
         app.data_system()
             .start_notify(&window_comp)
-            .wait_timeout(std::time::Duration::from_millis(100))
+            .wait_timeout(std::time::Duration::from_millis(1000))
             .expect("started");
 
         let win_ref: ActorRefStrong<ArconMessage<u64>> = window_comp
@@ -378,7 +381,8 @@ mod tests {
 
         node_manager_comp.on_definition(|cd| {
             // Insert the created Node into the NodeManager
-            cd.nodes.insert(NodeID::new(0), (window_comp, required_ref));
+            cd.nodes
+                .insert(GlobalNodeId::null(), (window_comp, required_ref));
         });
 
         (win_ref, sink)

--- a/arcon/src/stream/source/kafka.rs
+++ b/arcon/src/stream/source/kafka.rs
@@ -11,7 +11,7 @@ use rdkafka::{
     message::*,
     topic_partition_list::{Offset, TopicPartitionList},
 };
-use std::{sync::Arc, time::Duration, marker::PhantomData};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 /// Default timeout duration for consumer polling
 const DEFAULT_POLL_TIMEOUT_MS: u64 = 250;

--- a/arcon/src/stream/source/kafka.rs
+++ b/arcon/src/stream/source/kafka.rs
@@ -11,7 +11,7 @@ use rdkafka::{
     message::*,
     topic_partition_list::{Offset, TopicPartitionList},
 };
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration, marker::PhantomData};
 
 /// Default timeout duration for consumer polling
 const DEFAULT_POLL_TIMEOUT_MS: u64 = 250;
@@ -38,6 +38,7 @@ pub struct KafkaConsumerConf {
 
 impl KafkaConsumerConf {
     /// Set topic for the conf
+    #[must_use]
     pub fn with_topic(mut self, topic: &str) -> Self {
         self.topic = Some(topic.to_string());
         self
@@ -45,12 +46,14 @@ impl KafkaConsumerConf {
     /// Set poll timeout for the Kafka consumer
     ///
     /// If not defined, the default [DEFAULT_POLL_TIMEOUT] will be used.
+    #[must_use]
     pub fn with_poll_timeout(mut self, timeout_ms: u64) -> Self {
         self.poll_timeout_ms = timeout_ms;
         self
     }
 
     /// Configure rdkafka's ClientConfig
+    #[must_use]
     pub fn set(mut self, key: &str, value: &str) -> Self {
         self.client_config.set(key, value);
         self
@@ -93,7 +96,7 @@ where
     conf: KafkaConsumerConf,
     consumer: BaseConsumer<DefaultConsumerContext>,
     state: KafkaConsumerState<B>,
-    schema: S,
+    schema: PhantomData<S>,
 }
 
 impl<S, B> KafkaConsumer<S, B>
@@ -104,7 +107,7 @@ where
     pub fn new(
         conf: KafkaConsumerConf,
         mut state: KafkaConsumerState<B>,
-        schema: S,
+        _schema: S,
         source_index: usize,
         total_sources: usize,
     ) -> Self {
@@ -147,7 +150,7 @@ where
             conf,
             consumer,
             state,
-            schema,
+            schema: PhantomData,
         }
     }
 }
@@ -165,7 +168,7 @@ where
             .poll(Duration::from_millis(self.conf.poll_timeout()))
         {
             Some(Ok(msg)) => match msg.payload() {
-                Some(bytes) => match self.schema.from_bytes(bytes) {
+                Some(bytes) => match S::from_bytes(bytes) {
                     Ok(data) => {
                         let partition = msg.partition();
                         let offset = msg.offset();

--- a/arcon/src/stream/source/schema.rs
+++ b/arcon/src/stream/source/schema.rs
@@ -4,7 +4,7 @@ use arcon_state::backend::serialization::protobuf;
 pub trait SourceSchema: Send + Sync + Clone + 'static {
     type Data: ArconType;
 
-    fn from_bytes(&self, bytes: &[u8]) -> Result<Self::Data, SourceError>;
+    fn from_bytes(bytes: &[u8]) -> Result<Self::Data, SourceError>;
 }
 
 #[cfg(feature = "serde_json")]
@@ -45,7 +45,7 @@ where
 {
     type Data = IN;
 
-    fn from_bytes(&self, bytes: &[u8]) -> Result<Self::Data, SourceError> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self::Data, SourceError> {
         let s = std::str::from_utf8(bytes).map_err(|err| SourceError::Parse {
             msg: err.to_string(),
         })?;
@@ -93,7 +93,7 @@ where
 {
     type Data = IN;
 
-    fn from_bytes(&self, bytes: &[u8]) -> Result<Self::Data, SourceError> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self::Data, SourceError> {
         match protobuf::deserialize(bytes) {
             Ok(data) => Ok(data),
             Err(err) => Err(SourceError::Schema {

--- a/arcon/src/test/keyby_integration.rs
+++ b/arcon/src/test/keyby_integration.rs
@@ -34,9 +34,10 @@ const NUM_KEYS: usize = 256;
 const EVENT_COUNT: u64 = 99946; // Idk what's special about this number but 100k wasn't reliable
 
 fn operator_conf() -> OperatorConf {
-    let mut op_conf = OperatorConf::default();
-    op_conf.parallelism_strategy = ParallelismStrategy::Static(PARALLELISM);
-    op_conf
+    OperatorConf {
+        parallelism_strategy: ParallelismStrategy::Static(PARALLELISM),
+        ..Default::default()
+    }
 }
 
 // Sets up a pipeline of iterator -> event -> key_by -> enriched_event
@@ -100,7 +101,7 @@ fn enriched_event_stream() -> Stream<EnrichedEvent> {
 fn key_by_integration() {
     let mut app = enriched_event_stream().build();
     app.start();
-    sleep(Duration::from_secs(10));
+    sleep(Duration::from_secs(2));
 
     if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
         debug_node.on_definition(|c| {
@@ -110,7 +111,7 @@ fn key_by_integration() {
             }
             // all events were received by the debug node
             // assert_eq!(first_val_vec.len(), (EVENT_COUNT-2) as usize); // Something funky is happening to the events?
-            first_val_vec.sort();
+            first_val_vec.sort_unstable();
             first_val_vec.dedup();
             // Only NUM_KEYS number of first_val were received, i.e. State was handled properly
             assert_eq!(first_val_vec.len(), NUM_KEYS);
@@ -138,7 +139,7 @@ fn key_by_to_forward_integration() {
 
     app.start();
 
-    sleep(Duration::from_secs(10));
+    sleep(Duration::from_secs(2));
     if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
         debug_node.on_definition(|c| {
             let mut first_val_vec = Vec::new();
@@ -147,7 +148,7 @@ fn key_by_to_forward_integration() {
             }
             // all events were received by the debug node
             // assert_eq!(first_val_vec.len(), (EVENT_COUNT-2) as usize); // Something funky is happening to the events?
-            first_val_vec.sort();
+            first_val_vec.sort_unstable();
             first_val_vec.dedup();
             // Only NUM_KEYS number of first_val were received, i.e. State was handled properly
             assert_eq!(first_val_vec.len(), NUM_KEYS);

--- a/arcon/src/test/keyby_integration.rs
+++ b/arcon/src/test/keyby_integration.rs
@@ -101,7 +101,7 @@ fn enriched_event_stream() -> Stream<EnrichedEvent> {
 fn key_by_integration() {
     let mut app = enriched_event_stream().build();
     app.start();
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(4));
 
     if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
         debug_node.on_definition(|c| {
@@ -139,7 +139,7 @@ fn key_by_to_forward_integration() {
 
     app.start();
 
-    sleep(Duration::from_secs(2));
+    sleep(Duration::from_secs(4));
     if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
         debug_node.on_definition(|c| {
             let mut first_val_vec = Vec::new();

--- a/arcon/src/test/keyby_integration.rs
+++ b/arcon/src/test/keyby_integration.rs
@@ -1,0 +1,160 @@
+use crate::prelude::*;
+use rand::Rng;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[derive(Arcon, Arrow, prost::Message, Copy, Clone)]
+#[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
+pub struct Event {
+    #[prost(uint64)]
+    pub data: u64,
+    #[prost(uint32)]
+    pub key: u32,
+}
+
+#[derive(Arcon, Arrow, prost::Message, Copy, Clone)]
+#[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
+pub struct EnrichedEvent {
+    #[prost(uint64)]
+    pub data: u64,
+    #[prost(uint32)]
+    pub key: u32,
+    #[prost(uint64)]
+    pub first_val: u64,
+}
+
+#[derive(ArconState)]
+pub struct FirstVal<B: Backend> {
+    #[table = "Count"]
+    events: EagerValue<u64, B>,
+}
+
+const PARALLELISM: usize = 2;
+const NUM_KEYS: usize = 256;
+const EVENT_COUNT: u64 = 99946; // Idk what's special about this number but 100k wasn't reliable
+
+fn operator_conf() -> OperatorConf {
+    let mut op_conf = OperatorConf::default();
+    op_conf.parallelism_strategy = ParallelismStrategy::Static(PARALLELISM);
+    op_conf
+}
+
+// Sets up a pipeline of iterator -> event -> key_by -> enriched_event
+fn enriched_event_stream() -> Stream<EnrichedEvent> {
+    let app_conf = ApplicationConf {
+        epoch_interval: 2500,
+        ctrl_system_host: Some("127.0.0.1:0".to_string()),
+        ..Default::default()
+    };
+
+    Application::with_conf(app_conf)
+        .with_debug_node()
+        .iterator(0u64..EVENT_COUNT, |conf| {
+            conf.set_arcon_time(ArconTime::Event);
+            conf.set_timestamp_extractor(|x: &u64| *x);
+        })
+        .operator(OperatorBuilder {
+            // Map u64 -> Event
+            operator: Arc::new(move || {
+                Map::new({
+                    |i| {
+                        let mut rng = rand::thread_rng();
+                        let r: u32 = rng.gen();
+                        Event {
+                            data: i,
+                            key: r % (NUM_KEYS as u32),
+                        }
+                    }
+                })
+            }),
+            state: Arc::new(|_| EmptyState),
+            conf: operator_conf(),
+        })
+        .key_by(|event| &event.key)
+        .operator(OperatorBuilder {
+            operator: Arc::new(|| {
+                // Map Event -> EnrichedEvent
+                Map::stateful(|event: Event, state: &mut FirstVal<_>| {
+                    // Just use state somehow, this should be the same for all events
+                    let first_val: u64 = if let Some(value) = state.events().get()? {
+                        *value
+                    } else {
+                        state.events().put(event.data)?;
+                        event.data
+                    };
+                    Ok(EnrichedEvent {
+                        data: event.data,
+                        key: event.key,
+                        first_val,
+                    })
+                })
+            }),
+            state: Arc::new(|backend| FirstVal {
+                events: EagerValue::new("_events", backend),
+            }),
+            conf: operator_conf(),
+        })
+}
+
+#[test]
+fn key_by_integration() {
+    let mut app = enriched_event_stream().build();
+    app.start();
+    sleep(Duration::from_secs(10));
+
+    if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
+        debug_node.on_definition(|c| {
+            let mut first_val_vec = Vec::new();
+            for element in c.data.iter() {
+                first_val_vec.push(element.data.first_val);
+            }
+            // all events were received by the debug node
+            // assert_eq!(first_val_vec.len(), (EVENT_COUNT-2) as usize); // Something funky is happening to the events?
+            first_val_vec.sort();
+            first_val_vec.dedup();
+            // Only NUM_KEYS number of first_val were received, i.e. State was handled properly
+            assert_eq!(first_val_vec.len(), NUM_KEYS);
+            // The DebugNode received events from the same
+            assert_eq!(c.senders.len(), PARALLELISM);
+        })
+    } else {
+        panic!("Failed to get DebugNode!")
+    }
+}
+
+// Same test as above except we add another Map: EnrichedEvent -> EnrichedEvent with a Forward channel
+#[test]
+fn key_by_to_forward_integration() {
+    let mut app = enriched_event_stream()
+        .operator(OperatorBuilder {
+            operator: Arc::new(|| {
+                // Map EnrichedEvent -> EnrichedEvent
+                Map::new(|event: EnrichedEvent| event)
+            }),
+            state: Arc::new(|_| EmptyState),
+            conf: operator_conf(),
+        })
+        .build();
+
+    app.start();
+
+    sleep(Duration::from_secs(10));
+    if let Some(debug_node) = app.get_debug_node::<EnrichedEvent>() {
+        debug_node.on_definition(|c| {
+            let mut first_val_vec = Vec::new();
+            for element in c.data.iter() {
+                first_val_vec.push(element.data.first_val);
+            }
+            // all events were received by the debug node
+            // assert_eq!(first_val_vec.len(), (EVENT_COUNT-2) as usize); // Something funky is happening to the events?
+            first_val_vec.sort();
+            first_val_vec.dedup();
+            // Only NUM_KEYS number of first_val were received, i.e. State was handled properly
+            assert_eq!(first_val_vec.len(), NUM_KEYS);
+            // The DebugNode received events from two different nodes
+            assert_eq!(c.senders.len(), PARALLELISM);
+        })
+    } else {
+        panic!("Failed to get DebugNode!")
+    }
+}

--- a/arcon/src/test/mod.rs
+++ b/arcon/src/test/mod.rs
@@ -1,1 +1,2 @@
 mod arcon_state;
+mod keyby_integration;

--- a/examples/stateful.rs
+++ b/examples/stateful.rs
@@ -27,7 +27,7 @@ fn main() {
         .iterator((0..1000000).map(|x| Event { id: x, data: 1.5 }), |conf| {
             conf.set_timestamp_extractor(|x: &Event| x.id);
         })
-        //.key_by(Arc::new(|event: &Event| &event.id)) TODO
+        .key_by(|event: &Event| &event.id)
         .operator(OperatorBuilder {
             operator: Arc::new(|| {
                 Map::stateful(|event, state: &mut MyState<_>| {

--- a/examples/stateful.rs
+++ b/examples/stateful.rs
@@ -1,11 +1,12 @@
 use arcon::prelude::*;
 use std::sync::Arc;
 
-#[arcon::proto]
-#[derive(Arcon, Arrow, Copy, Clone)]
-#[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1, keys = "id")]
+#[derive(Arcon, Arrow, prost::Message, Copy, Clone)]
+#[arcon(unsafe_ser_id = 12, reliable_ser_id = 13, version = 1)]
 pub struct Event {
+    #[prost(uint64)]
     pub id: u64,
+    #[prost(float)]
     pub data: f32,
 }
 
@@ -26,6 +27,7 @@ fn main() {
         .iterator((0..1000000).map(|x| Event { id: x, data: 1.5 }), |conf| {
             conf.set_timestamp_extractor(|x: &Event| x.id);
         })
+        //.key_by(Arc::new(|event: &Event| &event.id)) TODO
         .operator(OperatorBuilder {
             operator: Arc::new(|| {
                 Map::stateful(|event, state: &mut MyState<_>| {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -18,7 +18,6 @@ fn main() {
                         slide: Time::seconds(500),
                         late_arrival: Time::seconds(0),
                     },
-                    kind: StreamKind::Keyed,
                 };
                 WindowAssigner::new(conf)
             }),


### PR DESCRIPTION
### Adds the method key_by(...) to Stream<T>

Type signature:
```
pub fn key_by<F, KEY>(mut self, key_extractor: F) -> Stream<T>
    where
        KEY: Hash + 'static,
        F: Fn(&T) -> &KEY + ArconFnBounds,
```

### ChannelKind::Forward
Since keyed ChannelKind is actually meaningful now it is no longer the default ChannelStrategy of operators. Instead the "Forward" channel strategy is the default and it has a slightly modified behaviour. If Operator A with parallelism Pa (nodes A1, A2... APa) sends messages, using the forward strategy, to Operator B with parallelism Pb (nodes B1, B2... BPb) then node A1 sends to B1 and A2 to B2 etc. Note: The program will fail to build the graph at runtime if Pa>Pb>1. If Pb>Pa there will be unused nodes in B.

### Refactoring
Also includes refactoring of the constructor.rs file and refactoring the way Application/AssembledApplication structs.

### Testing
I suppose the key_by() feature should be more well tested eventually but I believe this is about as good of a place as any to say "good enough", as the API is done and basic functionality is tested in the new integration test file.