### PR TITLE
chore: bump prost to 0.9

### DIFF
--- a/arcon/Cargo.toml
+++ b/arcon/Cargo.toml
@@ -49,7 +49,7 @@ fxhash = "0.2.1"
 twox-hash = "1.5.0"
 
 # Serialisation
-prost = "0.7"
+prost = "0.9"
 bytes = "1.0"
 serde = { version = "1.0.104", features = ["derive"] }
 

--- a/arcon/arcon_state/Cargo.toml
+++ b/arcon/arcon_state/Cargo.toml
@@ -16,7 +16,7 @@ rocks = ["rocksdb"]
 sled_checkpoints = ["sled"]
 
 [dependencies]
-prost = "0.7"
+prost = "0.9"
 bytes = "1.0"
 snafu = "0.6"
 once_cell = "1.3"

--- a/arcon_build/Cargo.toml
+++ b/arcon_build/Cargo.toml
@@ -6,4 +6,4 @@ repository = "https://github.com/cda-group/arcon"
 edition = "2018"
 
 [dependencies]
-prost-build = "0.7"
+prost-build = "0.9"

--- a/arcon_tests/Cargo.toml
+++ b/arcon_tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 arcon = { path = "../arcon" }
-prost = "0.7"
+prost = "0.9"
 
 [build-dependencies]
 arcon_build = { path = "../arcon_build"}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ kafka = ["arcon/kafka"]
 
 [dev-dependencies]
 arcon = { path = "../arcon" }
-prost = "0.7"
+prost = "0.9"
 
 [[example]]
 name = "custom_operator"

--- a/website/pages/docs/guide/getting-started.mdx
+++ b/website/pages/docs/guide/getting-started.mdx
@@ -21,7 +21,7 @@ as it is required when declaring more complex Arcon data types.
 ```rust
 [dependencies]
 arcon = "0.2"
-prost = "0.7"
+prost = "0.9"
 ```
 
 <CreatingApplication/>


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

close https://github.com/cda-group/arcon/issues/208

I've met with some compile error on my computer... Not sure if this would pass CI.

```
warning: unknown lint: `clippy::uninit_vec`
   --> arcon/src/buffer/event/mod.rs:217:13
    |
217 |     #[allow(clippy::uninit_vec)]
    |             ^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::unit_arg`
    |
    = note: `#[warn(unknown_lints)]` on by default

error: non-item macro in item position: panic
  --> arcon/src/index/hash_table/mod.rs:36:9
   |
36 |         panic!("sse2 needed for now");
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `super::EMPTY`
 --> arcon/src/index/hash_table/generic.rs:4:31
  |
4 | use super::{bitmask::BitMask, EMPTY};
  |                               ^^^^^ no `EMPTY` in `index::hash_table`

warning: unnecessary trailing semicolon
  --> arcon/src/index/hash_table/generic.rs:61:10
   |
61 |         };
   |          ^ help: remove this semicolon
   |
   = note: `#[warn(redundant_semicolons)]` on by default

error[E0599]: no method named `convert_mod_to_safe` found for struct `index::hash_table::generic::Group` in the current scope
   --> arcon/src/index/hash_table/table.rs:937:41
    |
937 |                 self.group = self.group.convert_mod_to_safe(self.table.meta(self.pos));
    |                                         ^^^^^^^^^^^^^^^^^^^ method not found in `index::hash_table::generic::Group`
    |
   ::: arcon/src/index/hash_table/generic.rs:40:1
    |
40  | pub struct Group(GroupWord);
    | ---------------------------- method `convert_mod_to_safe` not found for this

error[E0599]: no method named `convert_mod_to_safe` found for struct `index::hash_table::generic::Group` in the current scope
    --> arcon/src/index/hash_table/table.rs:1025:41
     |
1025 |                 self.group = self.group.convert_mod_to_safe(self.table.meta(self.pos));
     |                                         ^^^^^^^^^^^^^^^^^^^ method not found in `index::hash_table::generic::Group`
     |
    ::: arcon/src/index/hash_table/generic.rs:40:1
     |
40   | pub struct Group(GroupWord);
     | ---------------------------- method `convert_mod_to_safe` not found for this

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
warning: `arcon` (lib) generated 2 warnings
error: could not compile `arcon` due to 4 previous errors; 2 warnings emitted
warning: build failed, waiting for other jobs to finish...
warning: `arcon` (lib test) generated 2 warnings (2 duplicates)
error: build failed
```